### PR TITLE
build(deps): update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -33,17 +33,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sudo",
- "thiserror 2.0.12",
- "toml 0.9.5",
+ "thiserror",
+ "toml",
  "ureq",
  "which",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -56,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -71,44 +65,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -118,40 +112,54 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cairo-rs"
-version = "0.19.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562"
+checksum = "5cc8d9aa793480744cd9a0524fef1a2e197d9eaa0f739cde19d16aba530dcb95"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.19.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3bb3119664efbd78b5e6c93957447944f16bdbced84c17a9f41c7829b81e64"
+checksum = "f8b4985713047f5faee02b8db6a6ef32bbb50269ff53c1aee716d1d195b76d54"
 dependencies = [
  "glib-sys",
  "libc",
@@ -160,18 +168,19 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.8"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -179,35 +188,34 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cookie"
@@ -222,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
 dependencies = [
  "cookie",
  "document-features",
@@ -255,92 +263,120 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ctrlc"
-version = "3.5.0"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
- "dispatch",
+ "dispatch2",
  "nix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "powerfmt",
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
-
-[[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -356,16 +392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,50 +402,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -428,46 +454,45 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.19.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624eaba126021103c7339b2e179ae4ee8cdab842daab419040710f38ed9f8699"
+checksum = "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -477,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.19.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efa05a4f83c8cc50eb4d883787b919b85e5f1d8dd10b5a1df53bf5689782379"
+checksum = "48f31b37b1fc4b48b54f6b91b7ef04c18e00b4585d98359dd7b998774bbd91fb"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -490,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db265c9dd42d6a371e09e52deab3a84808427198b86ac792d75fd35c07990a07"
+checksum = "d81e2a6c6ecba2aab60633a98df1868b03fa0bfdce8105edc27c1bccf71f0e39"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -505,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9418fb4e8a67074919fe7604429c45aa74eb9df82e7ca529767c6d4e9dc66dd"
+checksum = "3d8f608d8d7d229975c4d0d026f5d3071598c4ddab3c5262b0a31840fec78d13"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -522,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -533,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c49f117d373ffcc98a35d114db5478bc223341cff53e39a5d6feced9e2ddffe"
+checksum = "8b3e1f669909c326b9413bde5a742097b8c90a7d78f45326db13668984769ded"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -546,29 +571,28 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "gio-sys"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef"
+checksum = "353fdc7da7cd16da916104b1e0e4e7de380ec9c8aaa20d4d742d66310ab4b0d5"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "glib"
-version = "0.19.9"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44"
+checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -581,27 +605,25 @@ dependencies = [
  "libc",
  "memchr",
  "smallvec",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.19.9"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7"
+checksum = "506d23499707c7142898429757e8d9a3871d965239a2cb66dfa05052be6d6f19"
 dependencies = [
  "heck",
- "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5"
+checksum = "030967459f9f676851872c6304adea7825c6d462ec9b72554c733cf0c5952233"
 dependencies = [
  "libc",
  "system-deps",
@@ -609,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.19.8"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e"
+checksum = "22a861859b887a79cf461359c192c97a57d8fb0229dd291232e57aa11f6fa72c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -620,32 +642,30 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb86031d24d9ec0a2a15978fc7a65d545a2549642cf1eb7c3dda358da42bcf"
+checksum = "eb856b9c558971c3f13ab692358926da710b046932a4e087aedcc35b040d7dff"
 dependencies = [
  "glib",
  "graphene-sys",
- "libc",
 ]
 
 [[package]]
 name = "graphene-sys"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f530e0944bccba4b55065e9c69f4975ad691609191ebac16e13ab8e1f27af05"
+checksum = "5c7ffdfde88f3570d3705e0d8a2433e036d387a1f2930bbf47eafcb5f569fd04"
 dependencies = [
  "glib-sys",
  "libc",
- "pkg-config",
  "system-deps",
 ]
 
 [[package]]
 name = "gsk4"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be"
+checksum = "b867be1c5f14dcb8f552c0eff6e9a9b1da5f8b43943e8efc3a63c889d84952ff"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -658,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23024bf2636c38bbd1f822f58acc9d1c25b28da896ff0f291a1a232d4272b3dc"
+checksum = "5b7c7eb2e681ee896646cfb8872b431f24d09f53ba9283289d9b10caa6707088"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -674,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04e11319b08af11358ab543105a9e49b0c491faca35e2b8e7e36bfba8b671ab"
+checksum = "98a0a0466484f64b07b5b8184d43fa46be78eb0b8e04ae4e179af31d770b76d9"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -695,21 +715,21 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec655a7ef88d8ce9592899deb8b2d0fa50bab1e6dd69182deb764e643c522408"
+checksum = "5ac7179400a36a04de039c24206bb841c5596992b907b43b23ee8d5bdc40d00e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "gtk4-sys"
-version = "0.8.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8aa86b7f85ea71d66ea88c1d4bae1cfacf51ca4856274565133838d77e57b5"
+checksum = "82b8f954786af0b1984425c4446b77f5ff6594346181316be3f850caab1c6f01"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -726,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -738,12 +758,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -755,9 +774,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -779,12 +798,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -792,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -805,11 +825,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -820,42 +839,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -865,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -876,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -886,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -896,47 +911,60 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -948,39 +976,33 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -998,15 +1020,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1014,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1028,34 +1051,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pango"
-version = "0.19.8"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0d328648058085cfd6897c9ae4272884098a926f3a833cd50c8c73e6eccecd"
+checksum = "5d800d8d0de2ad5d0fb046f5344dbaba14a003cf3dd27cc21d85893d35ea316c"
 dependencies = [
  "gio",
  "glib",
- "libc",
  "pango-sys",
 ]
 
 [[package]]
 name = "pango-sys"
-version = "0.19.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff03da4fa086c0b244d4a4587d3e20622a3ecdb21daea9edf66597224c634ba0"
+checksum = "bbd111a20ca90fedf03e09c59783c679c00900f1d8491cca5399f5e33609d5d6"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1065,48 +1102,42 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1119,36 +1150,36 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1158,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1169,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -1197,23 +1228,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1225,28 +1243,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1255,95 +1264,103 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
-dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -1363,9 +1380,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1380,94 +1408,73 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "system-deps"
-version = "6.2.2"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml 0.8.23",
+ "toml",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1475,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1485,26 +1492,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -1512,55 +1507,45 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
-dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "untrusted"
@@ -1570,9 +1555,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "cookie_store",
@@ -1580,20 +1565,19 @@ dependencies = [
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -1603,20 +1587,21 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1632,9 +1617,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -1650,35 +1635,22 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1686,109 +1658,101 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1797,34 +1761,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
-dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -1833,30 +1779,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1866,22 +1796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1890,22 +1808,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1914,22 +1820,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1938,51 +1832,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "winnow"
-version = "0.7.12"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1990,48 +1865,48 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2040,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2051,11 +1926,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ readme = "README.md"
 exclude = ["/.github", "/.fpm", "/Dockerfile"]
 
 [dependencies]
-gtk4 = { version = "0.8", features = ["v4_6"] }
+gtk4 = { version = "0.11", features = ["v4_6"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.9"
-csv = "1.3"
+toml = "1"
+csv = "1.4"
 which = "8"
 sudo = "0.6"
 ctrlc = "3.5"
-regex = "1.11"
+regex = "1.13"
 chrono = "0.4"
 lazy_static = "1"
-nix = { version = "0.30", features = ["signal"] }
+nix = { version = "0.31", features = ["signal"] }
 ureq = { version = "3", features = ["json"] }
 log = "0.4"
 env_logger = "0.11"
@@ -32,4 +32,4 @@ thiserror = "2"
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }
-csv = "1"
+csv = "1.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88.0-slim-bookworm
+FROM rust:1.94.1-slim-bookworm
 
 # Fetch package list
 RUN apt update

--- a/src/backend/app.rs
+++ b/src/backend/app.rs
@@ -77,16 +77,15 @@ pub fn check_required_dependencies(deps: &[&str]) -> Result<(), AppError> {
 pub fn check_update(current_version: &str) -> Option<String> {
     let url = "https://api.github.com/repos/martin-olivier/airgorah/releases/latest";
 
-    if let Ok(mut response) = ureq::get(url).call() {
-        if let Ok(json) = response.body_mut().read_json::<serde_json::Value>() {
-            if json["tag_name"] != current_version {
-                let new_version = json["tag_name"].as_str().unwrap_or("unknown").to_owned();
+    if let Ok(mut response) = ureq::get(url).call()
+        && let Ok(json) = response.body_mut().read_json::<serde_json::Value>()
+        && json["tag_name"] != current_version
+    {
+        let new_version = json["tag_name"].as_str().unwrap_or("unknown").to_owned();
 
-                log::info!("a new version is available: \"{new_version}\"");
+        log::info!("a new version is available: \"{new_version}\"");
 
-                return Some(new_version);
-            }
-        }
+        return Some(new_version);
     }
 
     log::info!("airgorah is up to date");

--- a/src/backend/scan.rs
+++ b/src/backend/scan.rs
@@ -292,10 +292,10 @@ pub fn get_airodump_data() -> HashMap<String, AP> {
             hidden = true;
             essid = format!("[Hidden] (length: {})", result.id_length.trim_start());
 
-            if let Some(old_ap_data) = old_ap_data {
-                if !old_ap_data.essid.starts_with("[Hidden] (length:") {
-                    essid = old_ap_data.essid.clone();
-                }
+            if let Some(old_ap_data) = old_ap_data
+                && !old_ap_data.essid.starts_with("[Hidden] (length:")
+            {
+                essid = old_ap_data.essid.clone();
             }
         }
 

--- a/src/backend/settings.rs
+++ b/src/backend/settings.rs
@@ -25,12 +25,12 @@ pub fn save_settings(mut settings: Settings) {
         settings.kill_network_manager = false;
     }
 
-    if Path::new(CONFIG_PATH).exists() {
-        if let Ok(toml_settings) = toml::to_string(&settings) {
-            std::fs::write(CONFIG_PATH, toml_settings).ok();
+    if Path::new(CONFIG_PATH).exists()
+        && let Ok(toml_settings) = toml::to_string(&settings)
+    {
+        std::fs::write(CONFIG_PATH, toml_settings).ok();
 
-            log::debug!("settings saved into '{CONFIG_PATH}'");
-        }
+        log::debug!("settings saved into '{CONFIG_PATH}'");
     }
     *SETTINGS.lock().unwrap() = settings;
 }

--- a/src/frontend/connections/app.rs
+++ b/src/frontend/connections/app.rs
@@ -17,14 +17,14 @@ use std::time::Duration;
 fn list_store_find(storage: &ListStore, pos: i32, to_match: &str) -> Option<TreeIter> {
     let mut iter = storage.iter_first();
 
-    while let Some(it) = iter {
+    while let Some(mut it) = iter {
         let value = list_store_get!(storage, &it, pos, String);
 
         if value == to_match {
             return Some(it);
         }
 
-        iter = match storage.iter_next(&it) {
+        iter = match storage.iter_next(&mut it) {
             true => Some(it),
             false => None,
         }
@@ -51,23 +51,30 @@ fn get_channel_entries(entry: &Entry) -> Vec<i32> {
 fn connect_window_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.app_gui.cli_view.selection().unselect_all();
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.app_gui.cli_view.selection().unselect_all();
 
-            if app_data.app_gui.aps_view.selection().selected().is_some() {
-                app_data.app_gui.aps_view.selection().unselect_all();
-                app_data.app_gui.cli_model.clear();
+                if app_data.app_gui.aps_view.selection().selected().is_some() {
+                    app_data.app_gui.aps_view.selection().unselect_all();
+                    app_data.app_gui.cli_model.clear();
+                }
+
+                app_data.app_gui.client_status_bar.pop(0);
+                app_data
+                    .app_gui
+                    .client_status_bar
+                    .push(0, "Showing unassociated clients");
+
+                update_buttons_sensitivity(&app_data);
             }
 
-            app_data.app_gui.client_status_bar.pop(0);
-            app_data.app_gui.client_status_bar.push(0, "Showing unassociated clients");
-
-            update_buttons_sensitivity(&app_data);
+            glib::Propagation::Proceed
         }
-
-        glib::Propagation::Proceed
-    }));
+    ));
 
     app_data.app_gui.window.add_controller(controller);
 }
@@ -75,156 +82,189 @@ fn connect_window_controller(app_data: Rc<AppData>) {
 fn connect_aps_controller(app: &Application, app_data: Rc<AppData>) {
     let gesture = GestureClick::new();
     gesture.set_button(gdk::ffi::GDK_BUTTON_SECONDARY as u32);
-    gesture.connect_pressed(clone!(@strong app_data => move |gesture, _, x, y| {
-        gesture.set_state(EventSequenceState::Claimed);
+    gesture.connect_pressed(clone!(
+        #[strong]
+        app_data,
+        move |gesture, _, x, y| {
+            gesture.set_state(EventSequenceState::Claimed);
 
-        if app_data.app_gui.aps_view.selection().selected().is_some() {
-            let pos = gdk::Rectangle::new(x as i32, y as i32, 0, 0);
+            if app_data.app_gui.aps_view.selection().selected().is_some() {
+                let pos = gdk::Rectangle::new(x as i32, y as i32, 0, 0);
 
-            app_data.app_gui.aps_menu.set_pointing_to(Some(&pos));
-            app_data.app_gui.aps_menu.popup();
+                app_data.app_gui.aps_menu.set_pointing_to(Some(&pos));
+                app_data.app_gui.aps_menu.popup();
+            }
         }
-    }));
+    ));
 
     app_data.app_gui.aps_scroll.add_controller(gesture);
 
     let copy_bssid = gio::SimpleAction::new("copy_bssid", None);
-    copy_bssid.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.aps_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_bssid.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.aps_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
+            let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&bssid);
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&bssid);
+            }
         }
-    }));
+    ));
     app.add_action(&copy_bssid);
 
     let copy_essid = gio::SimpleAction::new("copy_essid", None);
-    copy_essid.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.aps_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_essid.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.aps_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let essid = list_store_get!(app_data.app_gui.aps_model, &iter, 0, String);
+            let essid = list_store_get!(app_data.app_gui.aps_model, &iter, 0, String);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&essid);
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&essid);
+            }
         }
-    }));
+    ));
     app.add_action(&copy_essid);
 
     let copy_channel = gio::SimpleAction::new("copy_channel", None);
-    copy_channel.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.aps_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_channel.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.aps_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let channel = list_store_get!(app_data.app_gui.aps_model, &iter, 3, i32);
+            let channel = list_store_get!(app_data.app_gui.aps_model, &iter, 3, i32);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&channel.to_string());
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&channel.to_string());
+            }
         }
-    }));
+    ));
     app.add_action(&copy_channel);
 }
 
 fn connect_cli_controller(app: &Application, app_data: Rc<AppData>) {
     let gesture = GestureClick::new();
     gesture.set_button(gdk::ffi::GDK_BUTTON_SECONDARY as u32);
-    gesture.connect_pressed(clone!(@strong app_data => move |gesture, _, x, y| {
-        gesture.set_state(EventSequenceState::Claimed);
+    gesture.connect_pressed(clone!(
+        #[strong]
+        app_data,
+        move |gesture, _, x, y| {
+            gesture.set_state(EventSequenceState::Claimed);
 
-        if app_data.app_gui.cli_view.selection().selected().is_some() {
-            let pos = gdk::Rectangle::new(x as i32, y as i32, 0, 0);
+            if app_data.app_gui.cli_view.selection().selected().is_some() {
+                let pos = gdk::Rectangle::new(x as i32, y as i32, 0, 0);
 
-            app_data.app_gui.cli_menu.set_pointing_to(Some(&pos));
-            app_data.app_gui.cli_menu.popup();
+                app_data.app_gui.cli_menu.set_pointing_to(Some(&pos));
+                app_data.app_gui.cli_menu.popup();
+            }
         }
-    }));
+    ));
 
     app_data.app_gui.cli_scroll.add_controller(gesture);
 
     let copy_mac = gio::SimpleAction::new("copy_mac", None);
-    copy_mac.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.cli_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_mac.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.cli_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let mac = list_store_get!(app_data.app_gui.cli_model, &iter, 0, String);
+            let mac = list_store_get!(app_data.app_gui.cli_model, &iter, 0, String);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&mac);
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&mac);
+            }
         }
-    }));
+    ));
     app.add_action(&copy_mac);
 
     let copy_vendor = gio::SimpleAction::new("copy_vendor", None);
-    copy_vendor.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.cli_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_vendor.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.cli_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let vendor = list_store_get!(app_data.app_gui.cli_model, &iter, 5, String);
+            let vendor = list_store_get!(app_data.app_gui.cli_model, &iter, 5, String);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&vendor);
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&vendor);
+            }
         }
-    }));
+    ));
     app.add_action(&copy_vendor);
 
     let copy_probes = gio::SimpleAction::new("copy_probes", None);
-    copy_probes.connect_activate(clone!(@strong app_data => move |_, _| {
-        let iter = match app_data.app_gui.cli_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+    copy_probes.connect_activate(clone!(
+        #[strong]
+        app_data,
+        move |_, _| {
+            let iter = match app_data.app_gui.cli_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let probes = list_store_get!(app_data.app_gui.cli_model, &iter, 6, String);
+            let probes = list_store_get!(app_data.app_gui.cli_model, &iter, 6, String);
 
-        if let Some(display) = gdk::Display::default() {
-            display.clipboard().set_text(&probes);
+            if let Some(display) = gdk::Display::default() {
+                display.clipboard().set_text(&probes);
+            }
         }
-    }));
+    ));
     app.add_action(&copy_probes);
 }
 
 fn connect_about_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .about_button
-        .connect_clicked(clone!(@strong app_data => move |_| {
-        let icon = Pixbuf::from_read(BufReader::new(globals::APP_ICON)).unwrap();
-        let desc = "A WiFi security auditing software mainly based on aircrack-ng tools suite";
+    app_data.app_gui.about_button.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
+            let icon = Pixbuf::from_read(BufReader::new(globals::APP_ICON)).unwrap();
+            let desc = "A WiFi security auditing software mainly based on aircrack-ng tools suite";
 
-        AboutDialog::builder()
-            .program_name("Airgorah")
-            .version(globals::VERSION)
-            .authors(vec!["Martin OLIVIER (martin.olivier@live.fr)".to_string()])
-            .copyright("Copyright (c) Martin OLIVIER")
-            .license_type(License::MitX11)
-            .logo(&Picture::for_pixbuf(&icon).paintable().unwrap())
-            .comments(desc)
-            .website_label("https://github.com/martin-olivier/airgorah")
-            .transient_for(&app_data.app_gui.window)
-            .modal(true)
-            .build()
-            .show();
-        }));
+            AboutDialog::builder()
+                .program_name("Airgorah")
+                .version(globals::VERSION)
+                .authors(vec!["Martin OLIVIER (martin.olivier@live.fr)".to_string()])
+                .copyright("Copyright (c) Martin OLIVIER")
+                .license_type(License::MitX11)
+                .logo(&Picture::for_pixbuf(&icon).paintable().unwrap())
+                .comments(desc)
+                .website_label("https://github.com/martin-olivier/airgorah")
+                .transient_for(&app_data.app_gui.window)
+                .modal(true)
+                .build()
+                .show();
+        }
+    ));
 }
 
 fn connect_update_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .update_button
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.update_button.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let version = globals::VERSION;
             let new_version = globals::NEW_VERSION.lock().unwrap();
 
@@ -234,59 +274,67 @@ fn connect_update_button(app_data: Rc<AppData>) {
             };
 
             UpdateDialog::spawn(&app_data.app_gui.window, version, &new_version);
-        }));
+        }
+    ));
 }
 
 fn connect_decrypt_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .decrypt_button
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.decrypt_button.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.decrypt_gui.show(None);
-        }));
+        }
+    ));
 }
 
 fn connect_settings_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .settings_button
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.settings_button.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.settings_gui.show();
-        }));
+        }
+    ));
 }
 
 fn connect_hopping_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .hopping_but
-        .connect_clicked(clone!(@strong app_data => move |this| {
+    app_data.app_gui.hopping_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             app_data.app_gui.channel_filter_entry.set_text("");
 
             this.set_sensitive(false);
             update_buttons_sensitivity(&app_data);
-        }));
+        }
+    ));
 }
 
 fn connect_focus_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .focus_but
-        .connect_clicked(clone!(@strong app_data => move |this| {
+    app_data.app_gui.focus_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             if let Some((_, iter)) = app_data.app_gui.aps_view.selection().selected() {
                 let channel = list_store_get!(app_data.app_gui.aps_model, &iter, 3, i32);
-                app_data.app_gui.channel_filter_entry.set_text(&channel.to_string());
+                app_data
+                    .app_gui
+                    .channel_filter_entry
+                    .set_text(&channel.to_string());
 
                 this.set_sensitive(false);
                 app_data.app_gui.hopping_but.set_sensitive(true);
             }
-        }));
+        }
+    ));
 }
 
 fn connect_add_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .add_but
-        .connect_clicked(clone!(@strong app_data => move |this| {
+    app_data.app_gui.add_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             if let Some((_, iter)) = app_data.app_gui.aps_view.selection().selected() {
                 let channel = list_store_get!(app_data.app_gui.aps_model, &iter, 3, i32);
                 let entry = app_data.app_gui.channel_filter_entry.text();
@@ -305,18 +353,26 @@ fn connect_add_button(app_data: Rc<AppData>) {
 
                 let extend = match !entries.is_empty() {
                     true => format!(",{channel}"),
-                    false => format!("{channel}")
+                    false => format!("{channel}"),
                 };
 
-                if !backend::is_valid_channel_filter(&format!("{entry}{extend}"), ghz_2_4_but, ghz_5_but) {
+                if !backend::is_valid_channel_filter(
+                    &format!("{entry}{extend}"),
+                    ghz_2_4_but,
+                    ghz_5_but,
+                ) {
                     return;
                 }
 
-                app_data.app_gui.channel_filter_entry.set_text(&format!("{entry}{extend}"));
+                app_data
+                    .app_gui
+                    .channel_filter_entry
+                    .set_text(&format!("{entry}{extend}"));
                 app_data.app_gui.hopping_but.set_sensitive(true);
                 this.set_sensitive(false);
             }
-        }));
+        }
+    ));
 }
 
 pub fn update_buttons_sensitivity(app_data: &Rc<AppData>) {
@@ -390,8 +446,8 @@ pub fn update_buttons_sensitivity(app_data: &Rc<AppData>) {
 
     app_data.app_gui.deauth_but.set_sensitive(true);
 
-    let prev_iter = iter;
-    match app_data.app_gui.aps_model.iter_previous(&prev_iter) {
+    let mut prev_iter = iter;
+    match app_data.app_gui.aps_model.iter_previous(&mut prev_iter) {
         true => {
             app_data.app_gui.previous_but.set_sensitive(true);
             app_data.app_gui.top_but.set_sensitive(true);
@@ -402,8 +458,8 @@ pub fn update_buttons_sensitivity(app_data: &Rc<AppData>) {
         }
     }
 
-    let next_iter = iter;
-    match app_data.app_gui.aps_model.iter_next(&next_iter) {
+    let mut next_iter = iter;
+    match app_data.app_gui.aps_model.iter_next(&mut next_iter) {
         true => {
             app_data.app_gui.next_but.set_sensitive(true);
             app_data.app_gui.bottom_but.set_sensitive(true);
@@ -416,280 +472,352 @@ pub fn update_buttons_sensitivity(app_data: &Rc<AppData>) {
 }
 
 fn connect_previous_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .previous_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.previous_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let iter = match app_data.app_gui.aps_view.selection().selected() {
                 Some((_, iter)) => iter,
                 None => return update_buttons_sensitivity(&app_data),
             };
 
-            let prev_iter = iter;
-            if !app_data.app_gui.aps_model.iter_previous(&prev_iter) {
+            let mut prev_iter = iter;
+            if !app_data.app_gui.aps_model.iter_previous(&mut prev_iter) {
                 return update_buttons_sensitivity(&app_data);
             }
 
             let path = app_data.app_gui.aps_model.path(&prev_iter);
-            app_data.app_gui.aps_view.selection().select_iter(&prev_iter);
-            app_data.app_gui.aps_view.scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
+            app_data
+                .app_gui
+                .aps_view
+                .selection()
+                .select_iter(&prev_iter);
+            app_data
+                .app_gui
+                .aps_view
+                .scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
             app_data.app_gui.cli_model.clear();
 
             let essid = list_store_get!(app_data.app_gui.aps_model, &prev_iter, 0, String);
             app_data.app_gui.client_status_bar.pop(0);
-            app_data.app_gui.client_status_bar.push(0, &format!("Showing '{essid}' clients"));
+            app_data
+                .app_gui
+                .client_status_bar
+                .push(0, &format!("Showing '{essid}' clients"));
 
             update_buttons_sensitivity(&app_data);
-        }));
+        }
+    ));
 }
 
 fn connect_next_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .next_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.next_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let iter = match app_data.app_gui.aps_view.selection().selected() {
                 Some((_, iter)) => iter,
                 None => return update_buttons_sensitivity(&app_data),
             };
 
-            let next_iter = iter;
-            if !app_data.app_gui.aps_model.iter_next(&next_iter) {
+            let mut next_iter = iter;
+            if !app_data.app_gui.aps_model.iter_next(&mut next_iter) {
                 return update_buttons_sensitivity(&app_data);
             }
 
             let path = app_data.app_gui.aps_model.path(&next_iter);
-            app_data.app_gui.aps_view.selection().select_iter(&next_iter);
-            app_data.app_gui.aps_view.scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
+            app_data
+                .app_gui
+                .aps_view
+                .selection()
+                .select_iter(&next_iter);
+            app_data
+                .app_gui
+                .aps_view
+                .scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
             app_data.app_gui.cli_model.clear();
 
             let essid = list_store_get!(app_data.app_gui.aps_model, &next_iter, 0, String);
             app_data.app_gui.client_status_bar.pop(0);
-            app_data.app_gui.client_status_bar.push(0, &format!("Showing '{essid}' clients"));
+            app_data
+                .app_gui
+                .client_status_bar
+                .push(0, &format!("Showing '{essid}' clients"));
 
             update_buttons_sensitivity(&app_data);
-        }));
+        }
+    ));
 }
 
 fn connect_top_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .top_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.top_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let first_iter = match app_data.app_gui.aps_model.iter_first() {
                 Some(iter) => iter,
                 None => return update_buttons_sensitivity(&app_data),
             };
 
             let path = app_data.app_gui.aps_model.path(&first_iter);
-            app_data.app_gui.aps_view.selection().select_iter(&first_iter);
-            app_data.app_gui.aps_view.scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
+            app_data
+                .app_gui
+                .aps_view
+                .selection()
+                .select_iter(&first_iter);
+            app_data
+                .app_gui
+                .aps_view
+                .scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
             app_data.app_gui.cli_model.clear();
 
             let essid = list_store_get!(app_data.app_gui.aps_model, &first_iter, 0, String);
             app_data.app_gui.client_status_bar.pop(0);
-            app_data.app_gui.client_status_bar.push(0, &format!("Showing '{essid}' clients"));
+            app_data
+                .app_gui
+                .client_status_bar
+                .push(0, &format!("Showing '{essid}' clients"));
 
             update_buttons_sensitivity(&app_data);
-        }));
+        }
+    ));
 }
 
 fn connect_bottom_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .bottom_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
-            let iter = match app_data.app_gui.aps_model.iter_first() {
+    app_data.app_gui.bottom_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
+            let mut iter = match app_data.app_gui.aps_model.iter_first() {
                 Some(iter) => iter,
                 None => return update_buttons_sensitivity(&app_data),
             };
 
             let mut last_iter = iter;
 
-            while app_data.app_gui.aps_model.iter_next(&iter) {
+            while app_data.app_gui.aps_model.iter_next(&mut iter) {
                 last_iter = iter;
             }
 
             let path = app_data.app_gui.aps_model.path(&last_iter);
-            app_data.app_gui.aps_view.selection().select_iter(&last_iter);
-            app_data.app_gui.aps_view.scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
+            app_data
+                .app_gui
+                .aps_view
+                .selection()
+                .select_iter(&last_iter);
+            app_data
+                .app_gui
+                .aps_view
+                .scroll_to_cell(Some(&path), None, false, 0.0, 0.0);
             app_data.app_gui.cli_model.clear();
 
             let essid = list_store_get!(app_data.app_gui.aps_model, &last_iter, 0, String);
             app_data.app_gui.client_status_bar.pop(0);
-            app_data.app_gui.client_status_bar.push(0, &format!("Showing '{essid}' clients"));
+            app_data
+                .app_gui
+                .client_status_bar
+                .push(0, &format!("Showing '{essid}' clients"));
 
             update_buttons_sensitivity(&app_data);
-        }));
+        }
+    ));
 }
 
 fn start_app_refresh(app_data: Rc<AppData>) {
     glib::timeout_add_local(
         Duration::from_millis(100),
-        clone!(@strong app_data => move || {
-            match app_data.app_gui.aps_view.selection().selected() {
-                Some((_, iter)) => {
-                    let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
-                    let attack_pool = backend::get_attack_pool();
+        clone!(
+            #[strong]
+            app_data,
+            move || {
+                match app_data.app_gui.aps_view.selection().selected() {
+                    Some((_, iter)) => {
+                        let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
+                        let attack_pool = backend::get_attack_pool();
 
-                    match attack_pool.contains_key(&bssid) {
-                        true => {
-                            app_data.app_gui.deauth_but.set_icon(globals::STOP_ICON);
+                        match attack_pool.contains_key(&bssid) {
+                            true => {
+                                app_data.app_gui.deauth_but.set_icon(globals::STOP_ICON);
+                            }
+                            false => {
+                                app_data.app_gui.deauth_but.set_icon(globals::DEAUTH_ICON);
+                            }
                         }
-                        false => {
-                            app_data.app_gui.deauth_but.set_icon(globals::DEAUTH_ICON);
+
+                        match backend::get_aps()[&bssid].handshake {
+                            true => app_data.app_gui.capture_but.set_sensitive(true),
+                            false => app_data.app_gui.capture_but.set_sensitive(false),
                         }
                     }
-
-                    match backend::get_aps()[&bssid].handshake {
-                        true => app_data.app_gui.capture_but.set_sensitive(true),
-                        false => app_data.app_gui.capture_but.set_sensitive(false),
+                    None => {
+                        app_data.app_gui.deauth_but.set_icon(globals::DEAUTH_ICON);
                     }
-                }
-                None => {
-                    app_data.app_gui.deauth_but.set_icon(globals::DEAUTH_ICON);
-                }
-            };
-
-            let aps = backend::get_airodump_data();
-
-            for (bssid, ap) in aps.iter() {
-                if !backend::get_settings().display_hidden_ap && ap.hidden {
-                    if let Some(iter) =
-                        list_store_find(app_data.app_gui.aps_model.as_ref(), 1, bssid.as_str())
-                    {
-                        app_data.app_gui.aps_model.remove(&iter);
-                    }
-                    continue;
-                }
-
-                let it = match list_store_find(app_data.app_gui.aps_model.as_ref(), 1, bssid.as_str()) {
-                    Some(it) => it,
-                    None => app_data.app_gui.aps_model.append(),
                 };
 
-                let background_color = match backend::get_attack_pool().contains_key(bssid) {
-                    true => gdk::RGBA::RED,
-                    false => gdk::RGBA::new(0.0, 0.0, 0.0, 0.0),
-                };
+                let aps = backend::get_airodump_data();
 
-                app_data.app_gui.aps_model.set(
-                    &it,
-                    &[
-                        (0, &ap.essid),
-                        (1, &ap.bssid),
-                        (2, &ap.band),
-                        (3, &ap.channel.parse::<i32>().unwrap_or(-1)),
-                        (4, &ap.speed.parse::<i32>().unwrap_or(-1)),
-                        (5, &ap.power.parse::<i32>().unwrap_or(-1)),
-                        (6, &ap.privacy),
-                        (7, &(ap.clients.len() as i32)),
-                        (8, &ap.first_time_seen),
-                        (9, &ap.last_time_seen),
-                        (10, &ap.handshake),
-                        (11, &background_color.to_str()),
-                    ],
-                );
-            }
-
-            if let Some((_, iter)) = app_data.app_gui.aps_view.selection().selected() {
-                let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
-                let clients = &aps[&bssid].clients;
-
-                for (_, cli) in clients.iter() {
-                    let it =
-                        match list_store_find(app_data.app_gui.cli_model.as_ref(), 0, cli.mac.as_str())
+                for (bssid, ap) in aps.iter() {
+                    if !backend::get_settings().display_hidden_ap && ap.hidden {
+                        if let Some(iter) =
+                            list_store_find(app_data.app_gui.aps_model.as_ref(), 1, bssid.as_str())
                         {
+                            app_data.app_gui.aps_model.remove(&iter);
+                        }
+                        continue;
+                    }
+
+                    let it = match list_store_find(
+                        app_data.app_gui.aps_model.as_ref(),
+                        1,
+                        bssid.as_str(),
+                    ) {
+                        Some(it) => it,
+                        None => app_data.app_gui.aps_model.append(),
+                    };
+
+                    let background_color = match backend::get_attack_pool().contains_key(bssid) {
+                        true => gdk::RGBA::RED,
+                        false => gdk::RGBA::new(0.0, 0.0, 0.0, 0.0),
+                    };
+
+                    app_data.app_gui.aps_model.set(
+                        &it,
+                        &[
+                            (0, &ap.essid),
+                            (1, &ap.bssid),
+                            (2, &ap.band),
+                            (3, &ap.channel.parse::<i32>().unwrap_or(-1)),
+                            (4, &ap.speed.parse::<i32>().unwrap_or(-1)),
+                            (5, &ap.power.parse::<i32>().unwrap_or(-1)),
+                            (6, &ap.privacy),
+                            (7, &(ap.clients.len() as i32)),
+                            (8, &ap.first_time_seen),
+                            (9, &ap.last_time_seen),
+                            (10, &ap.handshake),
+                            (11, &background_color.to_str()),
+                        ],
+                    );
+                }
+
+                if let Some((_, iter)) = app_data.app_gui.aps_view.selection().selected() {
+                    let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
+                    let clients = &aps[&bssid].clients;
+
+                    for (_, cli) in clients.iter() {
+                        let it = match list_store_find(
+                            app_data.app_gui.cli_model.as_ref(),
+                            0,
+                            cli.mac.as_str(),
+                        ) {
                             Some(it) => it,
                             None => app_data.app_gui.cli_model.append(),
                         };
 
-                    let background_color = match backend::get_attack_pool().get(&bssid) {
-                        Some((_, attack_target)) => match &attack_target {
-                            AttackedClients::All(_) => gdk::RGBA::RED,
-                            AttackedClients::Selection(selection) => {
-                                let mut color = gdk::RGBA::new(0.0, 0.0, 0.0, 0.0);
+                        let background_color = match backend::get_attack_pool().get(&bssid) {
+                            Some((_, attack_target)) => match &attack_target {
+                                AttackedClients::All(_) => gdk::RGBA::RED,
+                                AttackedClients::Selection(selection) => {
+                                    let mut color = gdk::RGBA::new(0.0, 0.0, 0.0, 0.0);
 
-                                for (sel, _) in selection.iter() {
-                                    if sel == cli.mac.as_str() {
-                                        color = gdk::RGBA::RED;
+                                    for (sel, _) in selection.iter() {
+                                        if sel == cli.mac.as_str() {
+                                            color = gdk::RGBA::RED;
+                                        }
                                     }
+                                    color
                                 }
-                                color
-                            }
-                        },
-                        None => gdk::RGBA::new(0.0, 0.0, 0.0, 0.0),
-                    };
+                            },
+                            None => gdk::RGBA::new(0.0, 0.0, 0.0, 0.0),
+                        };
 
-                    app_data.app_gui.cli_model.set(
-                        &it,
-                        &[
-                            (0, &cli.mac),
-                            (1, &cli.packets.parse::<i32>().unwrap_or(-1)),
-                            (2, &cli.power.parse::<i32>().unwrap_or(-1)),
-                            (3, &cli.first_time_seen),
-                            (4, &cli.last_time_seen),
-                            (5, &cli.vendor),
-                            (6, &cli.probes),
-                            (7, &background_color.to_str()),
-                        ],
-                    );
+                        app_data.app_gui.cli_model.set(
+                            &it,
+                            &[
+                                (0, &cli.mac),
+                                (1, &cli.packets.parse::<i32>().unwrap_or(-1)),
+                                (2, &cli.power.parse::<i32>().unwrap_or(-1)),
+                                (3, &cli.first_time_seen),
+                                (4, &cli.last_time_seen),
+                                (5, &cli.vendor),
+                                (6, &cli.probes),
+                                (7, &background_color.to_str()),
+                            ],
+                        );
 
-                    if app_data.deauth_gui.window.is_visible() && list_store_find(app_data.deauth_gui.store.as_ref(), 1, cli.mac.as_str()).is_none() {
-                        app_data.deauth_gui.store.set(&app_data.deauth_gui.store.append(), &[(0, &false), (1, &cli.mac)]);
+                        if app_data.deauth_gui.window.is_visible()
+                            && list_store_find(
+                                app_data.deauth_gui.store.as_ref(),
+                                1,
+                                cli.mac.as_str(),
+                            )
+                            .is_none()
+                        {
+                            app_data.deauth_gui.store.set(
+                                &app_data.deauth_gui.store.append(),
+                                &[(0, &false), (1, &cli.mac)],
+                            );
+                        }
+                    }
+                } else {
+                    let clients = backend::get_unlinked_clients().clone();
+
+                    for (_, cli) in clients {
+                        let it = match list_store_find(
+                            app_data.app_gui.cli_model.as_ref(),
+                            0,
+                            cli.mac.as_str(),
+                        ) {
+                            Some(it) => it,
+                            None => app_data.app_gui.cli_model.append(),
+                        };
+
+                        app_data.app_gui.cli_model.set(
+                            &it,
+                            &[
+                                (0, &cli.mac),
+                                (1, &cli.packets.parse::<i32>().unwrap_or(-1)),
+                                (2, &cli.power.parse::<i32>().unwrap_or(-1)),
+                                (3, &cli.first_time_seen),
+                                (4, &cli.last_time_seen),
+                                (5, &cli.vendor),
+                                (6, &cli.probes),
+                                (7, &gdk::RGBA::new(0.0, 0.0, 0.0, 0.0).to_str()),
+                            ],
+                        );
                     }
                 }
-            } else {
-                let clients = backend::get_unlinked_clients().clone();
 
-                for (_, cli) in clients {
-                    let it = match list_store_find(app_data.app_gui.cli_model.as_ref(), 0, cli.mac.as_str()) {
-                        Some(it) => it,
-                        None => app_data.app_gui.cli_model.append(),
-                    };
-
-                    app_data.app_gui.cli_model.set(
-                        &it,
-                        &[
-                            (0, &cli.mac),
-                            (1, &cli.packets.parse::<i32>().unwrap_or(-1)),
-                            (2, &cli.power.parse::<i32>().unwrap_or(-1)),
-                            (3, &cli.first_time_seen),
-                            (4, &cli.last_time_seen),
-                            (5, &cli.vendor),
-                            (6, &cli.probes),
-                            (7, &gdk::RGBA::new(0.0, 0.0, 0.0, 0.0).to_str()),
-                        ],
-                    );
+                if !backend::get_aps().is_empty() {
+                    app_data.app_gui.export_but.set_sensitive(true);
+                    app_data.app_gui.report_but.set_sensitive(true);
                 }
+
+                update_buttons_sensitivity(&app_data);
+
+                ControlFlow::Continue
             }
-
-            if !backend::get_aps().is_empty() {
-                app_data.app_gui.export_but.set_sensitive(true);
-                app_data.app_gui.report_but.set_sensitive(true);
-            }
-
-            update_buttons_sensitivity(&app_data);
-
-            ControlFlow::Continue
-        }),
+        ),
     );
 
     glib::timeout_add_local(
         Duration::from_millis(1000),
-        clone!(@strong app_data => move || {
-            let mut updater = globals::UPDATE_PROC.lock().unwrap();
+        clone!(
+            #[strong]
+            app_data,
+            move || {
+                let mut updater = globals::UPDATE_PROC.lock().unwrap();
 
-            if let Some(proc) = updater.as_mut() {
-                if proc.is_finished() {
+                if let Some(proc) = updater.as_mut()
+                    && proc.is_finished()
+                {
                     if updater.take().unwrap().join().unwrap_or(false) {
                         app_data.app_gui.update_button.show();
                     }
                     return ControlFlow::Break;
                 }
+                ControlFlow::Continue
             }
-            ControlFlow::Continue
-        }),
+        ),
     );
 }
 
@@ -731,10 +859,10 @@ fn start_update_checker() {
 }
 
 fn connect_deauth_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .deauth_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.deauth_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let iter = match app_data.app_gui.aps_view.selection().selected() {
                 Some((_, iter)) => iter,
                 None => return,
@@ -747,18 +875,22 @@ fn connect_deauth_button(app_data: Rc<AppData>) {
             match under_attack {
                 true => backend::stop_deauth_attack(&bssid),
                 false => {
-                    app_data.app_gui.channel_filter_entry.set_text(&channel.to_string());
+                    app_data
+                        .app_gui
+                        .channel_filter_entry
+                        .set_text(&channel.to_string());
                     app_data.deauth_gui.show(backend::get_aps()[&bssid].clone());
                 }
             }
-        }));
+        }
+    ));
 }
 
 fn connect_capture_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .capture_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.capture_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let iter = match app_data.app_gui.aps_view.selection().selected() {
                 Some((_, iter)) => iter,
                 None => return,
@@ -792,39 +924,48 @@ fn connect_capture_button(app_data: Rc<AppData>) {
                 FileChooserAction::Save,
                 &[
                     ("Cancel", ResponseType::Cancel),
-                    ("Save", ResponseType::Accept)
+                    ("Save", ResponseType::Accept),
                 ],
             );
 
             file_chooser_dialog.set_current_name(&format!("{essid}.cap"));
-            file_chooser_dialog.run_async(clone!(@strong app_data => move |this, response| {
-                if response == ResponseType::Accept {
-                    this.close();
+            file_chooser_dialog.run_async(clone!(
+                #[strong]
+                app_data,
+                move |this, response| {
+                    if response == ResponseType::Accept {
+                        this.close();
 
-                    let gio_file = match this.file() {
-                        Some(file) => file,
-                        None => return,
-                    };
-                    let path = gio_file.path().unwrap().to_str().unwrap().to_string();
+                        let gio_file = match this.file() {
+                            Some(file) => file,
+                            None => return,
+                        };
+                        let path = gio_file.path().unwrap().to_str().unwrap().to_string();
 
-                    if let Err(e) = backend::save_capture(&path) {
-                        return ErrorDialog::spawn(&app_data.app_gui.window, "Save failed", &e.to_string());
-                    }
-
-                    for (_, ap) in backend::get_aps().iter_mut() {
-                        if ap.handshake {
-                            ap.saved_handshake = Some(path.to_owned());
+                        if let Err(e) = backend::save_capture(&path) {
+                            return ErrorDialog::spawn(
+                                &app_data.app_gui.window,
+                                "Save failed",
+                                &e.to_string(),
+                            );
                         }
+
+                        for (_, ap) in backend::get_aps().iter_mut() {
+                            if ap.handshake {
+                                ap.saved_handshake = Some(path.to_owned());
+                            }
+                        }
+
+                        app_data.decrypt_gui.show(Some((path, bssid)));
                     }
 
-                    app_data.decrypt_gui.show(Some((path, bssid)));
+                    if was_scanning {
+                        app_data.app_gui.scan_but.emit_clicked();
+                    }
                 }
-
-                if was_scanning {
-                    app_data.app_gui.scan_but.emit_clicked();
-                }
-            }));
-        }));
+            ));
+        }
+    ));
 }
 
 pub fn connect(app: &Application, app_data: Rc<AppData>) {

--- a/src/frontend/connections/deauth.rs
+++ b/src/frontend/connections/deauth.rs
@@ -14,7 +14,7 @@ fn get_selected_clients(storage: &ListStore) -> Vec<String> {
     let mut iter = storage.iter_first();
     let mut selected_clients = vec![];
 
-    while let Some(it) = iter {
+    while let Some(mut it) = iter {
         let check_val = list_store_get!(storage, &it, 0, bool);
         let mac_val = list_store_get!(storage, &it, 1, String);
 
@@ -22,7 +22,7 @@ fn get_selected_clients(storage: &ListStore) -> Vec<String> {
             selected_clients.push(mac_val);
         }
 
-        iter = match storage.iter_next(&it) {
+        iter = match storage.iter_next(&mut it) {
             true => Some(it),
             false => None,
         }
@@ -34,100 +34,119 @@ fn get_selected_clients(storage: &ListStore) -> Vec<String> {
 fn connect_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.deauth_gui.window.hide();
-        }
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.deauth_gui.window.hide();
+            }
 
-        glib::Propagation::Proceed
-    }));
+            glib::Propagation::Proceed
+        }
+    ));
 
     app_data.deauth_gui.window.add_controller(controller);
 }
 
 fn connect_all_cli_button(app_data: Rc<AppData>) {
-    app_data
-        .deauth_gui
-        .all_cli_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.deauth_gui.all_cli_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.deauth_gui.view.set_sensitive(false);
             app_data.deauth_gui.view.selection().unselect_all();
             app_data.deauth_gui.attack_but.set_sensitive(true);
-        }));
+        }
+    ));
 }
 
 fn connect_sel_cli_button(app_data: Rc<AppData>) {
-    app_data
-        .deauth_gui
-        .sel_cli_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.deauth_gui.sel_cli_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.deauth_gui.view.set_sensitive(true);
 
             if get_selected_clients(&app_data.deauth_gui.store).is_empty() {
                 app_data.deauth_gui.attack_but.set_sensitive(false);
             }
-        }));
+        }
+    ));
 }
 
 fn connect_toggle(app_data: Rc<AppData>) {
-    app_data
-        .deauth_gui
-        .toggle
-        .connect_toggled(clone!(@strong app_data => move |_, path| {
+    app_data.deauth_gui.toggle.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_, path| {
             let iter = app_data.deauth_gui.store.iter(&path).unwrap();
             let old_val = list_store_get!(app_data.deauth_gui.store, &iter, 0, bool);
 
-            app_data.deauth_gui.store.set_value(&iter, 0, &Value::from(&(!old_val)));
+            app_data
+                .deauth_gui
+                .store
+                .set_value(&iter, 0, &Value::from(&(!old_val)));
 
             match get_selected_clients(&app_data.deauth_gui.store).is_empty() {
                 true => app_data.deauth_gui.attack_but.set_sensitive(false),
                 false => app_data.deauth_gui.attack_but.set_sensitive(true),
             };
-        }));
+        }
+    ));
 }
 
 fn connect_attack_but(app_data: Rc<AppData>) {
-    app_data.deauth_gui.attack_but.connect_clicked(clone!(@strong app_data => move |_| {
-        let params = match app_data.deauth_gui.sel_cli_but.is_active() {
-            true => Some(get_selected_clients(&app_data.deauth_gui.store)),
-            false => None,
-        };
+    app_data.deauth_gui.attack_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
+            let params = match app_data.deauth_gui.sel_cli_but.is_active() {
+                true => Some(get_selected_clients(&app_data.deauth_gui.store)),
+                false => None,
+            };
 
-        let iface = match backend::get_iface() {
-            Some(iface) => iface,
-            None => return,
-        };
+            let iface = match backend::get_iface() {
+                Some(iface) => iface,
+                None => return,
+            };
 
-        let iter = match app_data.app_gui.aps_view.selection().selected() {
-            Some((_, iter)) => iter,
-            None => return,
-        };
+            let iter = match app_data.app_gui.aps_view.selection().selected() {
+                Some((_, iter)) => iter,
+                None => return,
+            };
 
-        let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
+            let bssid = list_store_get!(app_data.app_gui.aps_model, &iter, 1, String);
 
-        let attack_software = match app_data.deauth_gui.aireplay_but.is_active() {
-            true => AttackSoftware::Aireplay,
-            false => AttackSoftware::Mdk4,
-        };
+            let attack_software = match app_data.deauth_gui.aireplay_but.is_active() {
+                true => AttackSoftware::Aireplay,
+                false => AttackSoftware::Mdk4,
+            };
 
-        if attack_software == AttackSoftware::Mdk4 && !backend::has_dependency("mdk4") {
-            return ErrorDialog::spawn(
-                &app_data.deauth_gui.window,
-                "Missing dependency",
-                "\"mdk4\" is not installed on your system",
-            );
+            if attack_software == AttackSoftware::Mdk4 && !backend::has_dependency("mdk4") {
+                return ErrorDialog::spawn(
+                    &app_data.deauth_gui.window,
+                    "Missing dependency",
+                    "\"mdk4\" is not installed on your system",
+                );
+            }
+
+            if let Err(e) = backend::launch_deauth_attack(
+                &iface,
+                backend::get_aps()[&bssid].clone(),
+                params,
+                attack_software,
+            ) {
+                return ErrorDialog::spawn(
+                    &app_data.deauth_gui.window,
+                    "Deauth attack failed",
+                    e.to_string().as_str(),
+                );
+            };
+
+            app_data.deauth_gui.window.hide();
         }
-
-        if let Err(e) = backend::launch_deauth_attack(&iface, backend::get_aps()[&bssid].clone(), params, attack_software) {
-            return ErrorDialog::spawn(
-                &app_data.deauth_gui.window,
-                "Deauth attack failed",
-                e.to_string().as_str(),
-            );
-        };
-
-        app_data.deauth_gui.window.hide();
-    }));
+    ));
 }
 
 pub fn connect(app_data: Rc<AppData>) {

--- a/src/frontend/connections/decrypt.rs
+++ b/src/frontend/connections/decrypt.rs
@@ -12,13 +12,17 @@ use std::rc::Rc;
 fn connect_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.decrypt_gui.window.hide();
-        }
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.decrypt_gui.window.hide();
+            }
 
-        glib::Propagation::Proceed
-    }));
+            glib::Propagation::Proceed
+        }
+    ));
 
     app_data.decrypt_gui.window.add_controller(controller);
 }
@@ -26,13 +30,17 @@ fn connect_controller(app_data: Rc<AppData>) {
 fn connect_settings_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.decrypt_gui.settings_gui.window.hide();
-        }
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.decrypt_gui.settings_gui.window.hide();
+            }
 
-        glib::Propagation::Proceed
-    }));
+            glib::Propagation::Proceed
+        }
+    ));
 
     app_data
         .decrypt_gui
@@ -68,74 +76,94 @@ fn update_decrypt_button_status(app_data: Rc<AppData>) {
 }
 
 fn connect_handshake_button(app_data: Rc<AppData>) {
-    app_data.decrypt_gui.handshake_but.connect_clicked(
-        clone!(@strong app_data => move |_| {
-
+    app_data.decrypt_gui.handshake_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let file_chooser_dialog = FileChooserDialog::new(
                 Some("Select capture"),
                 Some(&app_data.decrypt_gui.window),
                 FileChooserAction::Open,
                 &[
                     ("Cancel", ResponseType::Cancel),
-                    ("Open", ResponseType::Accept)
+                    ("Open", ResponseType::Accept),
                 ],
             );
 
-            file_chooser_dialog.run_async(clone!(@strong app_data => move |this, response| {
-                this.close();
+            file_chooser_dialog.run_async(clone!(
+                #[strong]
+                app_data,
+                move |this, response| {
+                    this.close();
 
-                if response == ResponseType::Accept {
-                    let gio_file = match this.file() {
-                        Some(file) => file,
-                        None => return,
-                    };
+                    if response == ResponseType::Accept {
+                        let gio_file = match this.file() {
+                            Some(file) => file,
+                            None => return,
+                        };
 
-                    let gio_path = gio_file.path().unwrap();
-                    let file_path = gio_path.to_str().unwrap();
+                        let gio_path = gio_file.path().unwrap();
+                        let file_path = gio_path.to_str().unwrap();
 
-                    let handshakes = backend::get_handshakes([file_path]).unwrap_or_default();
+                        let handshakes = backend::get_handshakes([file_path]).unwrap_or_default();
 
-                    if handshakes.is_empty() {
-                        return ErrorDialog::spawn(
-                            &app_data.decrypt_gui.window,
-                            "Invalid capture",
-                            &format!("\"{file_path}\" doesn't contain any valid handshake")
-                        );
+                        if handshakes.is_empty() {
+                            return ErrorDialog::spawn(
+                                &app_data.decrypt_gui.window,
+                                "Invalid capture",
+                                &format!("\"{file_path}\" doesn't contain any valid handshake"),
+                            );
+                        }
+
+                        app_data.decrypt_gui.target_model.clear();
+
+                        for (bssid, essid) in handshakes.iter() {
+                            app_data
+                                .decrypt_gui
+                                .target_model
+                                .insert_with_values(None, &[(0, &bssid), (1, &essid)]);
+                        }
+
+                        app_data
+                            .decrypt_gui
+                            .target_view
+                            .set_active(if !handshakes.is_empty() {
+                                Some(0)
+                            } else {
+                                None
+                            });
+
+                        app_data.decrypt_gui.handshake_entry.set_text(file_path);
+
+                        update_decrypt_button_status(app_data);
                     }
-
-                    app_data.decrypt_gui.target_model.clear();
-
-                    for (bssid, essid) in handshakes.iter() {
-                        app_data.decrypt_gui.target_model.insert_with_values(None, &[(0, &bssid), (1, &essid)]);
-                    }
-
-                    app_data.decrypt_gui.target_view.set_active(if !handshakes.is_empty() { Some(0) } else { None });
-
-                    app_data.decrypt_gui.handshake_entry.set_text(file_path);
-
-                    update_decrypt_button_status(app_data);
                 }
-            }));
-        }),
-    );
+            ));
+        }
+    ));
 }
 
 fn connect_stack_notify(app_data: Rc<AppData>) {
     app_data
         .decrypt_gui
         .stack
-        .connect_visible_child_notify(clone!(@strong app_data => move |_| {
-            update_decrypt_button_status(app_data.clone());
-        }));
+        .connect_visible_child_notify(clone!(
+            #[strong]
+            app_data,
+            move |_| {
+                update_decrypt_button_status(app_data.clone());
+            }
+        ));
 }
 
 fn connect_settings_button(app_data: Rc<AppData>) {
-    app_data
-        .decrypt_gui
-        .settings_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.settings_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.decrypt_gui.settings_gui.show();
-        }));
+        }
+    ));
 }
 
 fn connect_password_len_buttons(app_data: Rc<AppData>) {
@@ -143,114 +171,165 @@ fn connect_password_len_buttons(app_data: Rc<AppData>) {
         .decrypt_gui
         .settings_gui
         .min_but
-        .connect_value_changed(clone!(@strong app_data => move |min_but| {
-            let min_value = min_but.value();
+        .connect_value_changed(clone!(
+            #[strong]
+            app_data,
+            move |min_but| {
+                let min_value = min_but.value();
 
-            if min_value > app_data.decrypt_gui.settings_gui.max_but.value() {
-                app_data.decrypt_gui.settings_gui.max_but.set_value(min_value);
+                if min_value > app_data.decrypt_gui.settings_gui.max_but.value() {
+                    app_data
+                        .decrypt_gui
+                        .settings_gui
+                        .max_but
+                        .set_value(min_value);
+                }
             }
-        }));
+        ));
 
     app_data
         .decrypt_gui
         .settings_gui
         .max_but
-        .connect_value_changed(clone!(@strong app_data => move |max_but| {
-            let max_value = max_but.value();
+        .connect_value_changed(clone!(
+            #[strong]
+            app_data,
+            move |max_but| {
+                let max_value = max_but.value();
 
-            if max_value < app_data.decrypt_gui.settings_gui.min_but.value() {
-                app_data.decrypt_gui.settings_gui.min_but.set_value(max_value);
+                if max_value < app_data.decrypt_gui.settings_gui.min_but.value() {
+                    app_data
+                        .decrypt_gui
+                        .settings_gui
+                        .min_but
+                        .set_value(max_value);
+                }
             }
-        }));
+        ));
 }
 
 fn connect_charset_entry(app_data: Rc<AppData>) {
-    app_data.decrypt_gui.settings_gui.charset.connect_text_notify(
-        clone!(@strong app_data => move |this| {
-            let mut nodup_set = HashSet::new();
-            let nodup_str = this.text().chars().filter(|&c| nodup_set.insert(c)).collect::<String>();
+    app_data
+        .decrypt_gui
+        .settings_gui
+        .charset
+        .connect_text_notify(clone!(
+            #[strong]
+            app_data,
+            move |this| {
+                let mut nodup_set = HashSet::new();
+                let nodup_str = this
+                    .text()
+                    .chars()
+                    .filter(|&c| nodup_set.insert(c))
+                    .collect::<String>();
 
-            if nodup_str != this.text() {
-                return this.set_text(&nodup_str);
+                if nodup_str != this.text() {
+                    return this.set_text(&nodup_str);
+                }
+
+                let buttons_state = this.text().is_empty();
+
+                app_data
+                    .decrypt_gui
+                    .lowercase_but
+                    .set_sensitive(buttons_state);
+                app_data
+                    .decrypt_gui
+                    .uppercase_but
+                    .set_sensitive(buttons_state);
+                app_data
+                    .decrypt_gui
+                    .symbols_but
+                    .set_sensitive(buttons_state);
+                app_data
+                    .decrypt_gui
+                    .numbers_but
+                    .set_sensitive(buttons_state);
+
+                update_decrypt_button_status(app_data.clone());
             }
-
-            let buttons_state = this.text().is_empty();
-
-            app_data.decrypt_gui.lowercase_but.set_sensitive(buttons_state);
-            app_data.decrypt_gui.uppercase_but.set_sensitive(buttons_state);
-            app_data.decrypt_gui.symbols_but.set_sensitive(buttons_state);
-            app_data.decrypt_gui.numbers_but.set_sensitive(buttons_state);
-
-            update_decrypt_button_status(app_data.clone());
-        }),
-    );
+        ));
 }
 
 fn connect_wordlist_button(app_data: Rc<AppData>) {
-    app_data.decrypt_gui.wordlist_but.connect_clicked(
-        clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.wordlist_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let file_chooser_dialog = FileChooserDialog::new(
                 Some("Select wordlist"),
                 Some(&app_data.decrypt_gui.window),
                 FileChooserAction::Open,
                 &[
                     ("Cancel", ResponseType::Cancel),
-                    ("Open", ResponseType::Accept)
+                    ("Open", ResponseType::Accept),
                 ],
             );
 
-            file_chooser_dialog.run_async(clone!(@strong app_data => move |this, response| {
-                this.close();
+            file_chooser_dialog.run_async(clone!(
+                #[strong]
+                app_data,
+                move |this, response| {
+                    this.close();
 
-                if response == ResponseType::Accept {
-                    let gio_file = match this.file() {
-                        Some(file) => file,
-                        None => return,
-                    };
-                    app_data.decrypt_gui.wordlist_entry.set_text(gio_file.path().unwrap().to_str().unwrap());
+                    if response == ResponseType::Accept {
+                        let gio_file = match this.file() {
+                            Some(file) => file,
+                            None => return,
+                        };
+                        app_data
+                            .decrypt_gui
+                            .wordlist_entry
+                            .set_text(gio_file.path().unwrap().to_str().unwrap());
 
-                    update_decrypt_button_status(app_data);
+                        update_decrypt_button_status(app_data);
+                    }
                 }
-            }));
-        }),
-    );
+            ));
+        }
+    ));
 }
 
 fn connect_bruteforce_buttons(app_data: Rc<AppData>) {
-    app_data
-        .decrypt_gui
-        .lowercase_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.lowercase_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             update_decrypt_button_status(app_data.clone());
-        }));
+        }
+    ));
 
-    app_data
-        .decrypt_gui
-        .uppercase_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.uppercase_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             update_decrypt_button_status(app_data.clone());
-        }));
+        }
+    ));
 
-    app_data
-        .decrypt_gui
-        .numbers_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.numbers_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             update_decrypt_button_status(app_data.clone());
-        }));
+        }
+    ));
 
-    app_data
-        .decrypt_gui
-        .symbols_but
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.decrypt_gui.symbols_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             update_decrypt_button_status(app_data.clone());
-        }));
+        }
+    ));
 }
 
 fn connect_decrypt_button(app_data: Rc<AppData>) {
     app_data
         .decrypt_gui
         .decrypt_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+        .connect_clicked(clone!(#[strong] app_data, move |_| {
             let handshake_entry = app_data.decrypt_gui.handshake_entry.text();
             let wordlist_entry = app_data.decrypt_gui.wordlist_entry.text();
 
@@ -291,17 +370,17 @@ fn connect_decrypt_button(app_data: Rc<AppData>) {
                 ) {
                     return ErrorDialog::spawn(&app_data.decrypt_gui.window, "Failed to run decryption", &e.to_string());
                 }
-            } else if stack == "bruteforce" {
-                if let Err(e) = backend::run_decrypt_bruteforce_process(
+            } else if stack == "bruteforce"
+                && let Err(e) = backend::run_decrypt_bruteforce_process(
                     &handshake_entry,
                     &bssid,
                     &essid,
                     &charset,
                     min,
                     max,
-                ) {
-                    return ErrorDialog::spawn(&app_data.decrypt_gui.window, "Failed to run decryption", &e.to_string());
-                }
+                )
+            {
+                return ErrorDialog::spawn(&app_data.decrypt_gui.window, "Failed to run decryption", &e.to_string());
             }
 
             app_data.decrypt_gui.window.close();

--- a/src/frontend/connections/interface.rs
+++ b/src/frontend/connections/interface.rs
@@ -10,22 +10,26 @@ use std::rc::Rc;
 fn connect_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.interface_gui.window.hide();
-        }
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.interface_gui.window.hide();
+            }
 
-        glib::Propagation::Proceed
-    }));
+            glib::Propagation::Proceed
+        }
+    ));
 
     app_data.interface_gui.window.add_controller(controller);
 }
 
 fn connect_interface_refresh(app_data: Rc<AppData>) {
-    app_data
-        .interface_gui
-        .refresh_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.interface_gui.refresh_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.interface_gui.interface_model.clear();
 
             let ifaces = match backend::get_interfaces() {
@@ -40,19 +44,29 @@ fn connect_interface_refresh(app_data: Rc<AppData>) {
             };
 
             for iface in ifaces.iter() {
-                app_data.interface_gui.interface_model.insert_with_values(None, &[(0, &iface)]);
+                app_data
+                    .interface_gui
+                    .interface_model
+                    .insert_with_values(None, &[(0, &iface)]);
             }
 
-            app_data.interface_gui.interface_view.set_active(if !ifaces.is_empty() { Some(0) } else { None });
-            app_data.interface_gui.select_but.set_sensitive(!ifaces.is_empty());
-        }));
+            app_data
+                .interface_gui
+                .interface_view
+                .set_active(if !ifaces.is_empty() { Some(0) } else { None });
+            app_data
+                .interface_gui
+                .select_but
+                .set_sensitive(!ifaces.is_empty());
+        }
+    ));
 }
 
 fn connect_interface_select(app_data: Rc<AppData>) {
-    app_data
-        .interface_gui
-        .select_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.interface_gui.select_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let iter = match app_data.interface_gui.interface_view.active_iter() {
                 Some(iter) => iter,
                 None => return,
@@ -75,7 +89,10 @@ fn connect_interface_select(app_data: Rc<AppData>) {
 
                     backend::set_iface(iface.clone());
 
-                    app_data.app_gui.iface_status_bar.push(0, &format!("Interface: {iface}"));
+                    app_data
+                        .app_gui
+                        .iface_status_bar
+                        .push(0, &format!("Interface: {iface}"));
 
                     app_data.app_gui.restart_but.set_sensitive(true);
                     app_data.app_gui.channel_filter_entry.set_sensitive(true);
@@ -88,9 +105,10 @@ fn connect_interface_select(app_data: Rc<AppData>) {
                             app_data.app_gui.ghz_5_but.set_sensitive(true);
                             app_data.app_gui.ghz_5_but.set_active(true);
                         }
-                        false => app_data.app_gui.ghz_5_but.set_tooltip_text(Some(
-                            "Your network card doesn't support 5 GHz"
-                        ))
+                        false => app_data
+                            .app_gui
+                            .ghz_5_but
+                            .set_tooltip_text(Some("Your network card doesn't support 5 GHz")),
                     }
 
                     app_data.interface_gui.window.hide();
@@ -105,7 +123,8 @@ fn connect_interface_select(app_data: Rc<AppData>) {
                     );
                 }
             };
-        }));
+        }
+    ));
 }
 
 pub fn connect(app_data: Rc<AppData>) {

--- a/src/frontend/connections/scan.rs
+++ b/src/frontend/connections/scan.rs
@@ -47,8 +47,10 @@ fn run_scan(app_data: &AppData) {
 }
 
 fn connect_scan_button(app_data: Rc<AppData>) {
-    app_data.app_gui.scan_but.connect_clicked(
-        clone!(@strong app_data => move |this| match backend::is_scan_process() {
+    app_data.app_gui.scan_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |this| match backend::is_scan_process() {
             true => {
                 backend::stop_scan_process().ok();
                 this.set_icon_name("media-playback-start-symbolic");
@@ -56,15 +58,15 @@ fn connect_scan_button(app_data: Rc<AppData>) {
             false => {
                 run_scan(&app_data);
             }
-        }),
-    );
+        }
+    ));
 }
 
 fn connect_restart_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .restart_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.restart_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             backend::stop_scan_process().ok();
             backend::get_aps().clear();
             backend::get_unlinked_clients().clear();
@@ -73,14 +75,15 @@ fn connect_restart_button(app_data: Rc<AppData>) {
             app_data.app_gui.cli_model.clear();
 
             run_scan(&app_data);
-        }));
+        }
+    ));
 }
 
 fn connect_export_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .export_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.export_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             if backend::get_aps().is_empty() {
                 return;
             }
@@ -97,7 +100,7 @@ fn connect_export_button(app_data: Rc<AppData>) {
                 FileChooserAction::Save,
                 &[
                     ("Cancel", ResponseType::Cancel),
-                    ("Save", ResponseType::Accept)
+                    ("Save", ResponseType::Accept),
                 ],
             );
 
@@ -105,42 +108,51 @@ fn connect_export_button(app_data: Rc<AppData>) {
             let date = local.format("%Y-%m-%d-%Hh%M");
 
             file_chooser_dialog.set_current_name(&format!("capture_{date}.cap"));
-            file_chooser_dialog.run_async(clone!(@strong app_data => move |this, response| {
-                if response == ResponseType::Accept {
-                    this.close();
+            file_chooser_dialog.run_async(clone!(
+                #[strong]
+                app_data,
+                move |this, response| {
+                    if response == ResponseType::Accept {
+                        this.close();
 
-                    let gio_file = match this.file() {
-                        Some(file) => file,
-                        None => return,
-                    };
-                    let path = gio_file.path().unwrap().to_str().unwrap().to_string();
+                        let gio_file = match this.file() {
+                            Some(file) => file,
+                            None => return,
+                        };
+                        let path = gio_file.path().unwrap().to_str().unwrap().to_string();
 
-                    if let Err(e) = backend::save_capture(&path) {
-                        if was_scanning {
-                            app_data.app_gui.scan_but.emit_clicked();
+                        if let Err(e) = backend::save_capture(&path) {
+                            if was_scanning {
+                                app_data.app_gui.scan_but.emit_clicked();
+                            }
+                            return ErrorDialog::spawn(
+                                &app_data.app_gui.window,
+                                "Save failed",
+                                &e.to_string(),
+                            );
                         }
-                        return ErrorDialog::spawn(&app_data.app_gui.window, "Save failed", &e.to_string());
+
+                        for (_, ap) in backend::get_aps().iter_mut() {
+                            if ap.handshake {
+                                ap.saved_handshake = Some(path.to_owned());
+                            }
+                        }
                     }
 
-                    for (_, ap) in backend::get_aps().iter_mut() {
-                        if ap.handshake {
-                            ap.saved_handshake = Some(path.to_owned());
-                        }
+                    if was_scanning {
+                        app_data.app_gui.scan_but.emit_clicked();
                     }
                 }
-
-                if was_scanning {
-                    app_data.app_gui.scan_but.emit_clicked();
-                }
-            }));
-        }));
+            ));
+        }
+    ));
 }
 
 fn connect_report_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .report_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.app_gui.report_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             if backend::get_aps().is_empty() {
                 return;
             }
@@ -151,7 +163,7 @@ fn connect_report_button(app_data: Rc<AppData>) {
                 FileChooserAction::Save,
                 &[
                     ("Cancel", ResponseType::Cancel),
-                    ("Save", ResponseType::Accept)
+                    ("Save", ResponseType::Accept),
                 ],
             ));
 
@@ -159,30 +171,39 @@ fn connect_report_button(app_data: Rc<AppData>) {
             let date = local.format("%Y-%m-%d-%Hh%M");
 
             file_chooser_dialog.set_current_name(&format!("report_{date}.json"));
-            file_chooser_dialog.run_async(clone!(@strong app_data => move |this, response| {
-                if response == ResponseType::Accept {
-                    this.close();
+            file_chooser_dialog.run_async(clone!(
+                #[strong]
+                app_data,
+                move |this, response| {
+                    if response == ResponseType::Accept {
+                        this.close();
 
-                    let gio_file = match this.file() {
-                        Some(file) => file,
-                        None => return,
-                    };
+                        let gio_file = match this.file() {
+                            Some(file) => file,
+                            None => return,
+                        };
 
-                    let path = gio_file.path().unwrap().to_str().unwrap().to_string();
+                        let path = gio_file.path().unwrap().to_str().unwrap().to_string();
 
-                    if let Err(e) = backend::save_report(&path) {
-                        return ErrorDialog::spawn(&app_data.app_gui.window, "Save failed", &e.to_string());
+                        if let Err(e) = backend::save_report(&path) {
+                            return ErrorDialog::spawn(
+                                &app_data.app_gui.window,
+                                "Save failed",
+                                &e.to_string(),
+                            );
+                        }
                     }
                 }
-            }));
-        }));
+            ));
+        }
+    ));
 }
 
 fn connect_ghz_2_4_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .ghz_2_4_but
-        .connect_toggled(clone!(@strong app_data => move |this| {
+    app_data.app_gui.ghz_2_4_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             if !this.is_active() && !app_data.app_gui.ghz_5_but.is_active() {
                 if backend::is_scan_process() {
                     app_data.app_gui.scan_but.emit_clicked();
@@ -203,14 +224,15 @@ fn connect_ghz_2_4_button(app_data: Rc<AppData>) {
 
             let filter = app_data.app_gui.channel_filter_entry.text();
             app_data.app_gui.channel_filter_entry.set_text(&filter);
-        }));
+        }
+    ));
 }
 
 pub fn connect_ghz_5_button(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .ghz_5_but
-        .connect_toggled(clone!(@strong app_data => move |this| {
+    app_data.app_gui.ghz_5_but.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             let iface = match backend::get_iface() {
                 Some(iface) => iface,
                 None => return,
@@ -245,50 +267,58 @@ pub fn connect_ghz_5_button(app_data: Rc<AppData>) {
 
             let filter = app_data.app_gui.channel_filter_entry.text();
             app_data.app_gui.channel_filter_entry.set_text(&filter);
-        }));
+        }
+    ));
 }
 
 fn connect_channel_entry(app_data: Rc<AppData>) {
-    app_data.app_gui.channel_filter_entry.connect_text_notify(
-        clone!(@strong app_data => move |this| {
-            let channel_filter = this
-                .text()
-                .chars()
-                .filter(|c| c.is_numeric() || *c == ',')
-                .collect::<String>();
+    app_data
+        .app_gui
+        .channel_filter_entry
+        .connect_text_notify(clone!(
+            #[strong]
+            app_data,
+            move |this| {
+                let channel_filter = this
+                    .text()
+                    .chars()
+                    .filter(|c| c.is_numeric() || *c == ',')
+                    .collect::<String>();
 
-            if channel_filter != this.text() {
-                return this.set_text(&channel_filter);
+                if channel_filter != this.text() {
+                    return this.set_text(&channel_filter);
+                }
+
+                match channel_filter.is_empty() {
+                    true => app_data.app_gui.hopping_but.set_sensitive(false),
+                    false => app_data.app_gui.hopping_but.set_sensitive(true),
+                }
+
+                super::app::update_buttons_sensitivity(&app_data);
+
+                let ghz_2_4_but = app_data.app_gui.ghz_2_4_but.is_active();
+                let ghz_5_but = app_data.app_gui.ghz_5_but.is_active();
+
+                if !channel_filter.is_empty()
+                    && !backend::is_valid_channel_filter(&channel_filter, ghz_2_4_but, ghz_5_but)
+                {
+                    this.style_context().add_class("error");
+                } else {
+                    this.style_context().remove_class("error");
+                }
+
+                if backend::is_scan_process() {
+                    run_scan(&app_data);
+                }
             }
-
-            match channel_filter.is_empty() {
-                true => app_data.app_gui.hopping_but.set_sensitive(false),
-                false => app_data.app_gui.hopping_but.set_sensitive(true),
-            }
-
-            super::app::update_buttons_sensitivity(&app_data);
-
-            let ghz_2_4_but = app_data.app_gui.ghz_2_4_but.is_active();
-            let ghz_5_but = app_data.app_gui.ghz_5_but.is_active();
-
-            if !channel_filter.is_empty() && !backend::is_valid_channel_filter(&channel_filter, ghz_2_4_but, ghz_5_but) {
-                this.style_context().add_class("error");
-            } else {
-                this.style_context().remove_class("error");
-            }
-
-            if backend::is_scan_process() {
-                run_scan(&app_data);
-            }
-        }),
-    );
+        ));
 }
 
 fn connect_cursor_changed(app_data: Rc<AppData>) {
-    app_data
-        .app_gui
-        .aps_view
-        .connect_cursor_changed(clone!(@strong app_data => move |this| {
+    app_data.app_gui.aps_view.connect_cursor_changed(clone!(
+        #[strong]
+        app_data,
+        move |this| {
             super::app::update_buttons_sensitivity(&app_data);
 
             if let Some((_, it)) = this.selection().selected() {
@@ -297,7 +327,10 @@ fn connect_cursor_changed(app_data: Rc<AppData>) {
                 let aps = backend::get_aps();
 
                 app_data.app_gui.client_status_bar.pop(0);
-                app_data.app_gui.client_status_bar.push(0, &format!("Showing '{essid}' clients"));
+                app_data
+                    .app_gui
+                    .client_status_bar
+                    .push(0, &format!("Showing '{essid}' clients"));
 
                 let mut clients = match aps.get(&bssid) {
                     Some(ap) => ap.clients.keys().clone(),
@@ -305,24 +338,28 @@ fn connect_cursor_changed(app_data: Rc<AppData>) {
                 };
                 let mut cli_iter = app_data.app_gui.cli_model.iter_first();
 
-                while let Some(it) = cli_iter {
+                while let Some(mut it) = cli_iter {
                     let mac_val = list_store_get!(app_data.app_gui.cli_model, &it, 0, String);
 
                     if !clients.any(|x| &mac_val == x) {
                         break;
                     }
 
-                    cli_iter = match app_data.app_gui.cli_model.iter_next(&it) {
+                    cli_iter = match app_data.app_gui.cli_model.iter_next(&mut it) {
                         true => Some(it),
                         false => return,
                     }
                 }
             } else {
                 app_data.app_gui.client_status_bar.pop(0);
-                app_data.app_gui.client_status_bar.push(0, "Showing unassociated clients");
+                app_data
+                    .app_gui
+                    .client_status_bar
+                    .push(0, "Showing unassociated clients");
             }
             app_data.app_gui.cli_model.clear();
-        }));
+        }
+    ));
 }
 
 pub fn connect(app_data: Rc<AppData>) {

--- a/src/frontend/connections/settings.rs
+++ b/src/frontend/connections/settings.rs
@@ -11,50 +11,57 @@ use std::rc::Rc;
 fn connect_controller(app_data: Rc<AppData>) {
     let controller = gtk4::EventControllerKey::new();
 
-    controller.connect_key_pressed(clone!(@strong app_data => move |_, key, _, _| {
-        if key == gdk::Key::Escape {
-            app_data.settings_gui.window.hide();
-        }
+    controller.connect_key_pressed(clone!(
+        #[strong]
+        app_data,
+        move |_, key, _, _| {
+            if key == gdk::Key::Escape {
+                app_data.settings_gui.window.hide();
+            }
 
-        glib::Propagation::Proceed
-    }));
+            glib::Propagation::Proceed
+        }
+    ));
 
     app_data.settings_gui.window.add_controller(controller);
 }
 
 fn connect_random_mac_button(app_data: Rc<AppData>) {
-    app_data
-        .settings_gui
-        .random_mac
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.settings_gui.random_mac.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.settings_gui.mac_entry.set_sensitive(false);
             app_data.settings_gui.save_but.set_sensitive(true);
-        }));
+        }
+    ));
 }
 
 fn connect_default_mac_button(app_data: Rc<AppData>) {
-    app_data
-        .settings_gui
-        .default_mac
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.settings_gui.default_mac.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.settings_gui.mac_entry.set_sensitive(false);
             app_data.settings_gui.save_but.set_sensitive(true);
-        }));
+        }
+    ));
 }
 
 fn connect_specific_mac_button(app_data: Rc<AppData>) {
-    app_data
-        .settings_gui
-        .specific_mac
-        .connect_toggled(clone!(@strong app_data => move |_| {
+    app_data.settings_gui.specific_mac.connect_toggled(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             app_data.settings_gui.mac_entry.set_sensitive(true);
             app_data.settings_gui.mac_entry.notify("text");
-        }));
+        }
+    ));
 }
 
 fn connect_mac_entry(app_data: Rc<AppData>) {
     app_data.settings_gui.mac_entry.connect_text_notify(
-        clone!(@strong app_data => move |this| {
+        clone!(#[strong] app_data, move |this| {
             let mac_regex = Regex::new(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})|([0-9a-fA-F]{4}\\.[0-9a-fA-F]{4}\\.[0-9a-fA-F]{4})$").unwrap();
             let entry = this.text().to_string();
 
@@ -67,10 +74,10 @@ fn connect_mac_entry(app_data: Rc<AppData>) {
 }
 
 fn connect_save_but(app_data: Rc<AppData>) {
-    app_data
-        .settings_gui
-        .save_but
-        .connect_clicked(clone!(@strong app_data => move |_| {
+    app_data.settings_gui.save_but.connect_clicked(clone!(
+        #[strong]
+        app_data,
+        move |_| {
             let mut mac_address = Settings::default().mac_address;
 
             if app_data.settings_gui.random_mac.is_active() {
@@ -93,7 +100,8 @@ fn connect_save_but(app_data: Rc<AppData>) {
             backend::save_settings(settings);
 
             app_data.settings_gui.window.hide();
-        }));
+        }
+    ));
 }
 
 pub fn connect(app_data: Rc<AppData>) {

--- a/src/frontend/widgets/dialog.rs
+++ b/src/frontend/widgets/dialog.rs
@@ -71,10 +71,10 @@ impl UpdateDialog {
         dialog.add_button("Copy Link", ResponseType::Other(42));
 
         dialog.connect_response(|this, response| {
-            if response == ResponseType::Other(42) {
-                if let Some(display) = gdk::Display::default() {
-                    display.clipboard().set_text(link);
-                }
+            if response == ResponseType::Other(42)
+                && let Some(display) = gdk::Display::default()
+            {
+                display.clipboard().set_text(link);
             }
             this.close();
         });


### PR DESCRIPTION
Bump every direct dependency to its latest release and refresh the
lockfile:

- gtk4 0.8 -> 0.11
- toml 0.9 -> 1
- nix 0.30 -> 0.31
- regex 1.11 -> 1.13
- csv 1.3 -> 1.4 (also for build-dependencies)

Adapt the code to the gtk4/glib breaking changes:

- `clone!` now uses the attribute syntax (`#[strong] x,`) instead of the
  removed `@strong x =>` syntax
- `TreeModelExt::iter_next`/`iter_previous` now take `&mut TreeIter`

gtk4 0.11 requires Rust 1.92, so bump the builder image to 1.94.1 and
collapse the nested `if` blocks that the newer clippy reports.

Signed-off-by: Martin Olivier <martin.olivier@live.fr>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>