### PR TITLE
iface: probe 5 GHz support lazily when the band is toggled

### DIFF
--- a/crates/gui/src/frontend/connections/interface.rs
+++ b/crates/gui/src/frontend/connections/interface.rs
@@ -108,17 +108,8 @@ fn connect_interface_select(app_data: Rc<AppData>) {
 
                     app_data.app_gui.scan_but.emit_clicked();
 
-                    match backend::is_5ghz_supported(&iface).unwrap_or(false) {
-                        true => {
-                            app_data.app_gui.ghz_2_4_but.set_sensitive(true);
-                            app_data.app_gui.ghz_5_but.set_sensitive(true);
-                            app_data.app_gui.ghz_5_but.set_active(true);
-                        }
-                        false => app_data
-                            .app_gui
-                            .ghz_5_but
-                            .set_tooltip_text(Some("Your network card doesn't support 5 GHz")),
-                    }
+                    app_data.app_gui.ghz_2_4_but.set_sensitive(true);
+                    app_data.app_gui.ghz_5_but.set_sensitive(true);
 
                     app_data.interface_gui.window.hide();
                 }


### PR DESCRIPTION
The 5 GHz capability check ran during interface selection, right after Airgorah enabled monitor mode. Some drivers (notably rtw89 / RTL8852BE) don't advertise their 5 GHz channels via `iw phy info` for a short moment after the mode switch, so the probe returned false and the 5 GHz option was left permanently disabled, unless monitor mode had been enabled beforehand with airmon-ng, which gave the driver time to settle.

Make both band buttons selectable on interface selection with only 2.4 GHz enabled, and defer the 5 GHz probe to when the user actually toggles the 5 GHz button. By then the card has settled in monitor mode, so the check is reliable.