### PR TITLE
deps: declare pkexec and diagnose it when the agent is launched

### DIFF
--- a/crates/common/src/deps.rs
+++ b/crates/common/src/deps.rs
@@ -28,6 +28,7 @@ pub struct Tool {
 pub const MDK4: &str = "mdk4";
 pub const CRUNCH: &str = "crunch";
 pub const SYSTEMCTL: &str = "systemctl";
+pub const PKEXEC: &str = "pkexec";
 
 /// Every external tool airgorah shells out to.
 pub const TOOLS: &[Tool] = &[
@@ -101,6 +102,11 @@ pub const TOOLS: &[Tool] = &[
     Tool {
         name: SYSTEMCTL,
         requirer: Requirer::Both,
+        optional: true,
+    },
+    Tool {
+        name: PKEXEC,
+        requirer: Requirer::Gui,
         optional: true,
     },
 ];

--- a/crates/gui/src/backend/client.rs
+++ b/crates/gui/src/backend/client.rs
@@ -185,7 +185,14 @@ fn spawn_agent() -> Result<Child, AgentError> {
         command
     } else {
         // Normal case: escalate only the agent, via polkit.
-        let mut command = Command::new("pkexec");
+        if !deps::is_installed(deps::PKEXEC) {
+            return Err(AgentError(
+                "could not find 'pkexec' to start the privileged agent, install polkit, or run airgorah as root"
+                    .to_string(),
+            ));
+        }
+
+        let mut command = Command::new(deps::PKEXEC);
         command.arg(&agent);
         command
     };


### PR DESCRIPTION
An unprivileged GUI escalates only through `pkexec`, but that tool was absent from the dependency catalog, so a system without polkit failed at the first privileged action with the raw spawn error "No such file or directory", pointing at nothing the user could act on.

Declare it in the catalog as a GUI tool and check it in `spawn_agent`, right before the escalation, with a message naming polkit and the root fallback. It is optional rather than required on purpose: polkit is not installed everywhere and is deliberately not a package dependency, an already-root GUI spawns the agent directly without it, and the GUI's unprivileged features (handshake decryption, report export) work fine without ever escalating, so a missing pkexec must not block startup.