### PR TITLE
build: give path dependencies a version requirement for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ authors = ["Martin Olivier <martin.olivier@live.fr>"]
 homepage = "https://github.com/martin-olivier/airgorah"
 repository = "https://github.com/martin-olivier/airgorah"
 documentation = "https://github.com/martin-olivier/airgorah/wiki"
+readme = "README.md"
 
 [workspace.dependencies]
-airgorah-common = { path = "crates/common" }
+airgorah-common = { path = "crates/common", version = "0.8.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1.13"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Privileged agent process for airgorah: owns interface, scan, deauth and capture operations"
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
 
 [[bin]]
 name = "airgorah-agent"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Shared types and IPC protocol between the airgorah GUI and its privileged agent"
+homepage.workspace = true
+repository.workspace = true
+documentation.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/gui/Cargo.toml
+++ b/crates/gui/Cargo.toml
@@ -8,7 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 keywords = ["networking", "pentest", "aircrack-ng", "gui", "linux"]
-readme = "README.md"
+readme.workspace = true
 
 [[bin]]
 name = "airgorah"


### PR DESCRIPTION
`cargo publish` refuses a path dependency that carries no version requirement, since the path is stripped from the uploaded manifest and nothing would be left to resolve `airgorah-common` from crates.io. The workspace dependency declared only `path`, so the release aborted while verifying the agent manifest.