### PR TITLE
ui: show the channel the interface is listening on in the status bar

### DIFF
--- a/crates/agent/src/backend/scan.rs
+++ b/crates/agent/src/backend/scan.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use super::get_attack_pool;
 use super::sniffer;
@@ -22,6 +22,16 @@ pub enum ScanError {
 /// Check if a scan is currently running
 pub fn is_scan_process() -> bool {
     SCAN_HANDLE.lock().unwrap().is_some()
+}
+
+/// The channel the running capture thread is currently tuned to
+pub fn current_channel() -> Option<u32> {
+    SCAN_HANDLE
+        .lock()
+        .unwrap()
+        .as_ref()
+        .map(|handle| handle.channel.load(Ordering::Relaxed))
+        .filter(|channel| *channel != 0)
 }
 
 /// Start the native capture thread, or retune one already running on `iface`.
@@ -60,16 +70,19 @@ pub fn set_scan_process(
 
     let stop = Arc::new(AtomicBool::new(false));
     let channels = Arc::new(Mutex::new(channels));
+    let channel = Arc::new(AtomicU32::new(0));
     let thread_stop = stop.clone();
     let thread_channels = channels.clone();
+    let thread_channel = channel.clone();
     let thread_iface = iface.to_string();
     let handle = std::thread::spawn(move || {
-        sniffer::run(thread_iface, thread_channels, thread_stop);
+        sniffer::run(thread_iface, thread_channels, thread_channel, thread_stop);
     });
 
     SCAN_HANDLE.lock().unwrap().replace(ScanHandle {
         iface: iface.to_string(),
         channels,
+        channel,
         stop,
         handle,
     });

--- a/crates/agent/src/backend/sniffer.rs
+++ b/crates/agent/src/backend/sniffer.rs
@@ -24,7 +24,7 @@ use libwifi::frame::components::{DataHeader, ManagementHeader, RsnAkmSuite, Stat
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
 /// 2.4 GHz channels scanned when the band is enabled without a channel filter.
@@ -65,7 +65,15 @@ pub fn build_channel_list(ghz_2_4: bool, ghz_5: bool, filter: Option<&str>) -> V
 ///
 /// `channels` is shared and re-read every loop, so the GUI can change the bands or
 /// channel filter (and the scanner retunes) without the thread being restarted.
-pub fn run(iface: String, channels: Arc<Mutex<Vec<u32>>>, stop: Arc<AtomicBool>) {
+///
+/// `channel_out` is updated with the channel the card is tuned to on every hop, so
+/// the GUI can display the channel the interface is currently listening on.
+pub fn run(
+    iface: String,
+    channels: Arc<Mutex<Vec<u32>>>,
+    channel_out: Arc<AtomicU32>,
+    stop: Arc<AtomicBool>,
+) {
     let socket = match raw_socket::open(&iface) {
         Ok(socket) => socket,
         Err(e) => {
@@ -94,6 +102,7 @@ pub fn run(iface: String, channels: Arc<Mutex<Vec<u32>>>, stop: Arc<AtomicBool>)
     // Tune to the first channel up front.
     if let Some(&channel) = channels.lock().unwrap().first() {
         current_channel = channel;
+        channel_out.store(channel, Ordering::Relaxed);
         set_channel(&iface, channel);
     }
 
@@ -109,6 +118,7 @@ pub fn run(iface: String, channels: Arc<Mutex<Vec<u32>>>, stop: Arc<AtomicBool>)
         };
         if let Some(channel) = retune {
             current_channel = channel;
+            channel_out.store(channel, Ordering::Relaxed);
             set_channel(&iface, channel);
             last_hop = Instant::now();
         }

--- a/crates/agent/src/globals.rs
+++ b/crates/agent/src/globals.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU32;
 use std::thread::JoinHandle;
 
 /// Root-owned 0700 directory for the agent's scan/capture files.
@@ -25,11 +26,13 @@ pub static OLD_SCAN_PATH: &str = "/var/lib/airgorah/old_scan";
 /// `channels` is the live channel plan the thread re-reads each loop, so swapping
 /// it retunes a running scan without restarting the thread; `iface` identifies the
 /// interface the scan runs on, so a request for the same one can adapt it in place.
-/// `stop` is raised to ask the thread to exit; `handle` is joined to wait for it to
-/// finish flushing the capture file.
+/// `channel` is the channel the thread is currently tuned to (0 until the first
+/// hop), published so the GUI can show it. `stop` is raised to ask the thread to
+/// exit; `handle` is joined to wait for it to finish flushing the capture file.
 pub struct ScanHandle {
     pub iface: String,
     pub channels: Arc<Mutex<Vec<u32>>>,
+    pub channel: Arc<AtomicU32>,
     pub stop: Arc<AtomicBool>,
     pub handle: JoinHandle<()>,
 }

--- a/crates/agent/src/server.rs
+++ b/crates/agent/src/server.rs
@@ -176,11 +176,13 @@ fn dispatch(request: Request) -> (Response, bool) {
             let aps: Vec<AP> = backend::get_airodump_data().into_values().collect();
             let unlinked: Vec<Client> = backend::get_unlinked_clients().values().cloned().collect();
             let attacked = backend::get_attack_states();
+            let channel = backend::current_channel();
             (
                 Response::ScanData {
                     aps,
                     unlinked,
                     attacked,
+                    channel,
                 },
                 false,
             )

--- a/crates/common/src/ipc.rs
+++ b/crates/common/src/ipc.rs
@@ -105,6 +105,7 @@ pub enum Response {
         aps: Vec<AP>,
         unlinked: Vec<Client>,
         attacked: Vec<AttackState>,
+        channel: Option<u32>,
     },
     /// One chunk of the capture; `last` marks the final one.
     CaptureChunk {

--- a/crates/gui/src/backend/client.rs
+++ b/crates/gui/src/backend/client.rs
@@ -327,17 +327,23 @@ pub fn reset_scan_data() {
 pub fn get_airodump_data() -> HashMap<String, AP> {
     let response = match request(Request::GetScanData) {
         Ok(response) => response,
-        Err(_) => return get_aps().clone(),
+        Err(_) => {
+            *CURRENT_CHANNEL.lock().unwrap() = None;
+            return get_aps().clone();
+        }
     };
 
-    let (aps_vec, unlinked, attacked) = match response {
+    let (aps_vec, unlinked, attacked, channel) = match response {
         Response::ScanData {
             aps,
             unlinked,
             attacked,
-        } => (aps, unlinked, attacked),
+            channel,
+        } => (aps, unlinked, attacked, channel),
         _ => return get_aps().clone(),
     };
+
+    *CURRENT_CHANNEL.lock().unwrap() = channel;
 
     // GUI-side enrichment: merge the saved-handshake overlay onto the snapshot.
     // Vendors are already resolved by the agent, so there is nothing else to fill.
@@ -370,6 +376,10 @@ pub fn get_airodump_data() -> HashMap<String, AP> {
 
 pub fn get_aps() -> MutexGuard<'static, HashMap<String, AP>> {
     APS.lock().unwrap()
+}
+
+pub fn get_current_channel() -> Option<u32> {
+    *CURRENT_CHANNEL.lock().unwrap()
 }
 
 pub fn get_unlinked_clients() -> MutexGuard<'static, HashMap<String, Client>> {

--- a/crates/gui/src/frontend/connections/app.rs
+++ b/crates/gui/src/frontend/connections/app.rs
@@ -49,6 +49,19 @@ fn get_channel_entries(entry: &Entry) -> Vec<i32> {
     channels
 }
 
+/// Refresh the channel status bar with the channel the interface is
+/// currently listening on, as reported by the capture thread. Shows `none` when
+/// no scan is running (or the card has not tuned to a channel yet).
+pub fn update_channel_status(app_data: &Rc<AppData>) {
+    let text = match backend::get_current_channel() {
+        Some(channel) => format!("Channel: {channel}"),
+        None => String::from("Channel: none"),
+    };
+
+    app_data.app_gui.channel_status_bar.pop(0);
+    app_data.app_gui.channel_status_bar.push(0, &text);
+}
+
 /// The channels of every access point currently under attack, as a sorted,
 /// de-duplicated, comma-separated channel-filter string.
 fn attacked_channels_filter() -> String {
@@ -866,6 +879,7 @@ fn start_app_refresh(app_data: Rc<AppData>) {
                 }
 
                 drive_channel_filter_from_attacks(&app_data);
+                update_channel_status(&app_data);
                 update_buttons_sensitivity(&app_data);
 
                 ControlFlow::Continue

--- a/crates/gui/src/frontend/interfaces/app.rs
+++ b/crates/gui/src/frontend/interfaces/app.rs
@@ -339,6 +339,7 @@ pub struct AppGui {
     pub deauth_but: IconButton,
     pub capture_but: IconButton,
     pub client_status_bar: Statusbar,
+    pub channel_status_bar: Statusbar,
     pub iface_status_bar: Statusbar,
 }
 
@@ -486,20 +487,25 @@ impl AppGui {
         let client_status_bar = Statusbar::new();
         client_status_bar.push(0, "Showing unassociated clients");
 
+        let channel_status_bar = Statusbar::new();
+        channel_status_bar
+            .set_tooltip_text(Some("Channel the interface is currently listening on"));
+        channel_status_bar.push(0, "Channel: none");
+
         let iface_status_bar = Statusbar::new();
         iface_status_bar.set_tooltip_text(Some("Wireless interface used for scans and attacks"));
-        iface_status_bar.push(0, "No interface selected");
+        iface_status_bar.push(0, "Interface: none");
 
-        let panned_status_bar = Paned::new(Orientation::Horizontal);
-        panned_status_bar.set_wide_handle(true);
-        panned_status_bar.set_start_child(Some(&client_status_bar));
-        panned_status_bar.set_end_child(Some(&iface_status_bar));
+        let status_bar = Box::new(Orientation::Horizontal, 0);
+        status_bar.append(&client_status_bar);
+        status_bar.append(&channel_status_bar);
+        status_bar.append(&iface_status_bar);
 
-        client_status_bar.set_size_request(110, -1);
+        client_status_bar.set_hexpand(true);
 
         let vbox = Box::new(Orientation::Vertical, 0);
         vbox.append(&panned_cli_aps);
-        vbox.append(&panned_status_bar);
+        vbox.append(&status_bar);
 
         window.set_child(Some(&vbox));
 
@@ -536,6 +542,7 @@ impl AppGui {
             deauth_but,
             capture_but,
             client_status_bar,
+            channel_status_bar,
             iface_status_bar,
         }
     }

--- a/crates/gui/src/globals.rs
+++ b/crates/gui/src/globals.rs
@@ -27,6 +27,10 @@ lazy_static! {
     pub static ref UNLINKED_CLIENTS: Mutex<HashMap<String, Client>> = Mutex::new(HashMap::new());
     pub static ref ATTACK_POOL: Mutex<HashMap<String, AttackState>> = Mutex::new(HashMap::new());
 
+    /// Channel the interface is currently listening on, mirrored from each
+    /// `GetScanData` snapshot, `None` when no scan is running.
+    pub static ref CURRENT_CHANNEL: Mutex<Option<u32>> = Mutex::new(None);
+
     /// GUI-side overlay: which APs have had their handshake saved to which file.
     /// Merged onto incoming snapshots for display (the agent knows nothing of it).
     pub static ref SAVED_HANDSHAKES: Mutex<HashMap<String, String>> = Mutex::new(HashMap::new());


### PR DESCRIPTION
Add a "Channel: X" / "Channel: none" indicator to the bottom status bar, parked at the end next to the interface indicator.

The status bar is no longer resizable: the client-context bar takes the slack on the left while the two bounded-width indicators sit at the end, with the interface last so it stays put as the channel value keeps changing.

To surface the live channel, the capture thread now publishes the channel it is currently tuned to via a shared atomic in ScanHandle, updated on every hop. The agent returns it in the GetScanData response, the GUI mirrors it into a global, and the scan refresh timer keeps the indicator in sync. It reads "none" when no scan is running (or the card has not tuned to a channel yet).