### PR TITLE
scan: validate channel filters against the real channel list

### DIFF
--- a/crates/agent/src/backend/sniffer.rs
+++ b/crates/agent/src/backend/sniffer.rs
@@ -15,6 +15,7 @@ use super::pcap::PcapWriter;
 use super::raw_socket;
 use super::scan::{get_aps, get_cap_ext, get_live_scan_path, get_unlinked_clients};
 
+use airgorah_common::channel::{CHANNELS_2_4, CHANNELS_5};
 use airgorah_common::types::{AP, Client};
 
 use libwifi::Addresses;
@@ -26,17 +27,6 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::{Duration, Instant};
-
-/// 2.4 GHz channels scanned when the band is enabled without a channel filter.
-const CHANNELS_2_4: &[u32] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
-
-/// 5 GHz channels scanned when the band is enabled without a channel filter.
-/// DFS channels are included; the card may refuse some depending on the
-/// regulatory domain, in which case that hop is simply skipped.
-const CHANNELS_5: &[u32] = &[
-    36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
-    149, 153, 157, 161, 165,
-];
 
 /// How long to dwell on each channel while hopping.
 const HOP_INTERVAL: Duration = Duration::from_millis(250);

--- a/crates/common/src/channel.rs
+++ b/crates/common/src/channel.rs
@@ -1,35 +1,45 @@
-//! Channel-filter validation. Pure logic, shared so the GUI can validate input
-//! for UX and the agent can re-validate it as a trust boundary before the value
-//! ever reaches a command line.
+//! Channels and channel-filter validation. Pure logic and data, shared so the
+//! GUI can validate input for UX and the agent can re-validate it.
+
+/// 2.4 GHz channels scanned when the band is enabled without a channel filter.
+pub const CHANNELS_2_4: &[u32] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+/// 5 GHz channels scanned when the band is enabled without a channel filter.
+pub const CHANNELS_5: &[u32] = &[
+    36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 120, 124, 128, 132, 136, 140, 144,
+    149, 153, 157, 161, 165,
+];
 
 /// Check whether a comma-separated channel filter is valid for the selected bands.
+///
+/// Every entry must be one of the known [`CHANNELS_2_4`] / [`CHANNELS_5`] channels
+/// whose band is enabled, with no duplicates and no trailing comma. An empty
+/// filter is valid (it means "no filter", the enabled bands decide what is scanned).
 pub fn is_valid_channel_filter(channel_filter: &str, ghz_2_4_but: bool, ghz_5_but: bool) -> bool {
-    let channel_list: Vec<String> = channel_filter
-        .split_terminator(',')
-        .map(String::from)
-        .collect();
-
-    let mut channel_buf = vec![];
-
     if channel_filter.ends_with(',') {
         return false;
     }
 
-    for channel_str in channel_list {
+    let mut channel_buf = vec![];
+
+    for channel_str in channel_filter.split_terminator(',') {
         let channel = match channel_str.parse::<u32>() {
             Ok(chan) => chan,
             Err(_) => return false,
         };
 
-        if channel < 1 || (15..=35).contains(&channel) || channel > 165 {
+        let is_2_4 = CHANNELS_2_4.contains(&channel);
+        let is_5 = CHANNELS_5.contains(&channel);
+
+        if !is_2_4 && !is_5 {
             return false;
         }
 
-        if (1..=14).contains(&channel) && !ghz_2_4_but {
+        if is_2_4 && !ghz_2_4_but {
             return false;
         }
 
-        if (36..=165).contains(&channel) && !ghz_5_but {
+        if is_5 && !ghz_5_but {
             return false;
         }
 
@@ -41,4 +51,45 @@ pub fn is_valid_channel_filter(channel_filter: &str, ghz_2_4_but: bool, ghz_5_bu
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_is_valid() {
+        // No filter means "use the enabled bands", regardless of which are on.
+        assert!(is_valid_channel_filter("", true, true));
+        assert!(is_valid_channel_filter("", false, false));
+    }
+
+    #[test]
+    fn accepts_known_channels_for_enabled_bands() {
+        assert!(is_valid_channel_filter("1,6,11", true, false));
+        assert!(is_valid_channel_filter("36,149,165", false, true));
+        assert!(is_valid_channel_filter("1,36", true, true));
+    }
+
+    #[test]
+    fn rejects_channels_whose_band_is_disabled() {
+        assert!(!is_valid_channel_filter("1", false, true));
+        assert!(!is_valid_channel_filter("36", true, false));
+    }
+
+    #[test]
+    fn rejects_out_of_plan_5ghz_channels() {
+        assert!(!is_valid_channel_filter("163", true, true));
+        assert!(!is_valid_channel_filter("37", true, true));
+        assert!(!is_valid_channel_filter("145", true, true));
+    }
+
+    #[test]
+    fn rejects_malformed_input() {
+        assert!(!is_valid_channel_filter("1,", true, true)); // trailing comma
+        assert!(!is_valid_channel_filter(",1", true, true)); // leading comma
+        assert!(!is_valid_channel_filter("1,,6", true, true)); // empty entry
+        assert!(!is_valid_channel_filter("x", true, true)); // not a number
+        assert!(!is_valid_channel_filter("6,6", true, true)); // duplicate
+    }
 }


### PR DESCRIPTION
is_valid_channel_filter accepted any value in 36..=165, so invalid 5 GHz channels such as 163, 37 or 145 passed validation even though the scanner never hops to them.

Move the CHANNELS_2_4 / CHANNELS_5 scan lists into the shared common crate and validate filter entries by membership in those lists, so the validator and the scanner draw from a single source of truth.

Channel 14, which the old range check accepted but which is not in the scan plan, is now rejected too.