### PR TITLE
ui: close the file chooser dialog when the user cancels

### DIFF
--- a/crates/gui/src/frontend/connections/app.rs
+++ b/crates/gui/src/frontend/connections/app.rs
@@ -994,9 +994,9 @@ fn connect_capture_button(app_data: Rc<AppData>) {
                 #[strong]
                 app_data,
                 move |this, response| {
-                    if response == ResponseType::Accept {
-                        this.close();
+                    this.close();
 
+                    if response == ResponseType::Accept {
                         let gio_file = match this.file() {
                             Some(file) => file,
                             None => return,

--- a/crates/gui/src/frontend/connections/scan.rs
+++ b/crates/gui/src/frontend/connections/scan.rs
@@ -111,9 +111,9 @@ fn connect_export_button(app_data: Rc<AppData>) {
                 #[strong]
                 app_data,
                 move |this, response| {
-                    if response == ResponseType::Accept {
-                        this.close();
+                    this.close();
 
+                    if response == ResponseType::Accept {
                         let gio_file = match this.file() {
                             Some(file) => file,
                             None => return,
@@ -170,9 +170,9 @@ fn connect_report_button(app_data: Rc<AppData>) {
                 #[strong]
                 app_data,
                 move |this, response| {
-                    if response == ResponseType::Accept {
-                        this.close();
+                    this.close();
 
+                    if response == ResponseType::Accept {
                         let gio_file = match this.file() {
                             Some(file) => file,
                             None => return,


### PR DESCRIPTION
The "Save capture" and "Save report" dialogs called this.close() inside the ResponseType::Accept branch, so pressing Cancel ran the response callback, did nothing, and left the dialog on screen. Escape looked like the only way out because GtkWindow closes the window itself on Escape, without going through the callback.

gtk4's run_async never closes the dialog on its own: it disconnects the response handler and hands the response to the callback, which owns the dialog's lifetime from there. Close it before branching on the response, as the capture and wordlist choosers in decrypt.rs already do, so every response tears the dialog down.

The "Save capture" dialog raised when opening a handshake for decryption shared the same pattern and is fixed too.